### PR TITLE
better formatting for consul-template/template.json.jinja

### DIFF
--- a/salt/consul/etc/consul-template/template.json.jinja
+++ b/salt/consul/etc/consul-template/template.json.jinja
@@ -1,5 +1,5 @@
 template {
     source = "{{ source }}"
     destination = "{{ destination }}"
-    {%- if command %}command = "{{ command }}"{% endif %}
+    {% if command %}command = "{{ command }}"{% endif %}
 }


### PR DESCRIPTION
Simple formatting change which keeps 'command =..' in a new line (instead of joining it with 'destination = ..' line)