### PR TITLE
Expires headers for www.python.org static content

### DIFF
--- a/salt/pydotorg/config/pydotorg.nginx.jinja
+++ b/salt/pydotorg/config/pydotorg.nginx.jinja
@@ -250,14 +250,17 @@ server {
 
   location /m/ {
     alias /srv/pydotorg/media/;
+    expires 7d;
   }
 
   location /static/ {
     alias /srv/pydotorg/pythondotorg/static-root/;
+    expires 7d;
   }
 
   location /images/ {
     alias /srv/pydotorg/pythondotorg/static-root/images/;
+    expires 7d;
   }
 
   location / {


### PR DESCRIPTION
Add 7 day expire headers to:

    - /m/*
    - /static/*
    - /images/*