### PR TITLE
Remove the /jobs/ redirect

### DIFF
--- a/salt/pydotorg/config/pydotorg.nginx.jinja
+++ b/salt/pydotorg/config/pydotorg.nginx.jinja
@@ -122,11 +122,7 @@ server {
   }
 
   location /Jobs.html {
-    return 301 https://www.python.org/community/jobs/;
-  }
-
-  location /jobs/ {
-    return 301 https://www.python.org/community/jobs/;
+    return 301 https://www.python.org/jobs/;
   }
 
   location /Help.html {


### PR DESCRIPTION
The jobs app will go live this week and it will be hosted at
/jobs/.

Update the old Jobs.html redirect to the new location.