### PR TITLE
Redirect /newjobs URLs to /jobs

### DIFF
--- a/salt/pydotorg/config/pydotorg.nginx.jinja
+++ b/salt/pydotorg/config/pydotorg.nginx.jinja
@@ -125,6 +125,10 @@ server {
     return 301 https://www.python.org/jobs/;
   }
 
+  location ~ ^/newjobs(.*)$ {
+    return 301 https://www.python.org/jobs$1;
+  }
+
   location /Help.html {
     return 301 https://www.python.org/about/help;
   }


### PR DESCRIPTION
We used to run the jobs app under /newjobs during development
and had the RSS feed URL public for a short while. The redirect
should enable us to remove the second location of the jobs app,
avoiding duplicate URLs for every single job posting.