### PR TITLE
Add basic auth to /2016 part of Pycon site

### DIFF
--- a/salt/pycon/config/htpasswd
+++ b/salt/pycon/config/htpasswd
@@ -1,0 +1,1 @@
+pycon:PghYnB9jFEt2A

--- a/salt/pycon/config/pycon.nginx.jinja
+++ b/salt/pycon/config/pycon.nginx.jinja
@@ -48,6 +48,8 @@ server {
     client_max_body_size 20M;
     proxy_pass http://pycon;
     proxy_set_header Host $http_host;
+    auth_basic "New site coming soon";
+    auth_basic_user_file {{ auth_file }};
   }
   rewrite ^/$ /2015/ redirect;
 }

--- a/salt/pycon/init.sls
+++ b/salt/pycon/init.sls
@@ -140,6 +140,15 @@ pycon-requirements:
     - group: root
     - mode: 644
 
+/srv/pycon/htpasswd:
+  file.managed:
+    - source: salt://pycon/config/htpasswd
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - user: pycon-user
+
 /etc/nginx/sites.d/pycon.conf:
   file.managed:
     - source: salt://pycon/config/pycon.nginx.jinja
@@ -149,8 +158,11 @@ pycon-requirements:
     - mode: 644
     - context:
       server_names: {{ config['server_names']|join(' ') }}
+      use_basic_auth: {{ config['use_basic_auth'] }}
+      auth_file: /srv/pycon/htpasswd
     - require:
       - sls: nginx
+      - file: /srv/pycon/htpasswd
 
 pre-reload:
   cmd.run:


### PR DESCRIPTION
Until we're ready, require a userid and password to
access the /2016/ part of the Pycon site.