### PR TITLE
add X-Robots-Tag to staging responses

### DIFF
--- a/salt/pycon/config/pycon.nginx.jinja
+++ b/salt/pycon/config/pycon.nginx.jinja
@@ -23,6 +23,10 @@ server {
 
   server_name {{ grains['fqdn'] }} {{ server_names }};
 
+  {% if deployment == 'staging' %}
+  add_header X-Robots-Tag "noindex, nofollow"
+  {% endif %}
+
   location /2016/site_media/static {
     alias /srv/pycon/site_media/static;
   }

--- a/salt/pycon/init.sls
+++ b/salt/pycon/init.sls
@@ -178,6 +178,7 @@ pycon-requirements:
       server_names: {{ config['server_names']|join(' ') }}
       use_basic_auth: {{ config['use_basic_auth'] }}
       auth_file: /srv/pycon/htpasswd
+      deployment: {{ config["deployment"] }}
     - require:
       - sls: nginx
       - file: /srv/pycon/htpasswd


### PR DESCRIPTION
Looks like @brandon-rhodes has been notified that staging sites are being indexed by Google and confusing users searching for PyCon 2016 RFP.

This should stop the indexing and we can request the existing results are removed.