### PR TITLE
Make sure Pycon servers have en_US.UTF-8 locale

### DIFF
--- a/salt/pycon/init.sls
+++ b/salt/pycon/init.sls
@@ -5,6 +5,16 @@ include:
   - nginx
   - postgresql.client
 
+us_locale:
+  locale.present:
+    - name: en_US.UTF-8
+
+default_locale:
+  locale.system:
+    - name: en_US.UTF-8
+    - require:
+      - locale: us_locale
+
 git:
   pkg.installed
 
@@ -214,6 +224,7 @@ pycon:
       - file: /etc/init/pycon.conf
       - file: /var/log/pycon/
       - file: /srv/pycon/media/
+      - locale: us_locale
       - cmd: pre-reload
     - watch:
       - file: /etc/init/pycon.conf
@@ -227,6 +238,7 @@ pycon_worker:
       - file: /etc/init/pycon_worker.conf
       - file: /var/log/pycon/
       - file: /srv/pycon/media/
+      - locale: us_locale
       - cmd: pre-reload
     - watch:
       - file: /etc/init/pycon_worker.conf


### PR DESCRIPTION
It didn't occur to me that the servers might not have it already.

Note: I don't think the servers will be restarted by deploying this, since that only happens when source changes, so we might need to do that manually.