### PR TITLE
Revamp postgres tls

### DIFF
--- a/pillar/base/firewall/postgresql.sls
+++ b/pillar/base/firewall/postgresql.sls
@@ -1,10 +1,8 @@
 {% include "networking.sls" %}
 
 firewall:
-  postgresql-psf-internal:
+  postgresql:
     port: 5432
-    source: *psf_internal_network
 
-  postgresql-pypi-internal:
-    port: 5432
-    source: *pypi_internal_network
+fwmangle:
+  postgresql-stunnel: -A OUTPUT -p tcp -m multiport --sports 5431 -j MARK --set-xmark 0x1/0xffffffff

--- a/pillar/base/tls.sls
+++ b/pillar/base/tls.sls
@@ -50,7 +50,6 @@ tls:
         - loadbalancer
 
     postgresql.psf.io:
-      days: 7
       roles:
         - postgresql
 

--- a/salt/firewall/config/iptables.jinja
+++ b/salt/firewall/config/iptables.jinja
@@ -1,6 +1,21 @@
 # Firewall configuration written by salt
 # Manual customization of this file is not cool.
 
+{% set rules = salt['pillar.get']('fwmangle', {}) %}
+{% if rules %}
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+{% for name, rule in rules.iteritems() -%}
+# {{ name }}
+{{ rule }}
+{% endfor %}
+COMMIT
+{% endif %}
+
 {% set rules = salt['pillar.get']('firewall', {}) %}
 
 *filter

--- a/salt/postgresql/server/configs/pg_hba.conf.jinja
+++ b/salt/postgresql/server/configs/pg_hba.conf.jinja
@@ -13,7 +13,7 @@ local   all             postgres                                peer
 host    all             diamond         127.0.0.1/32            md5
 
 # Replication
-host replication       replicator       0.0.0.0/0               md5
+host replication       replicator       {{ psf_internal }}      md5
 
 # Application Databases
 host monitoring        monitoring       0.0.0.0/0               md5

--- a/salt/postgresql/server/configs/pg_hba.conf.jinja
+++ b/salt/postgresql/server/configs/pg_hba.conf.jinja
@@ -13,14 +13,14 @@ local   all             postgres                                peer
 host    all             diamond         127.0.0.1/32            md5
 
 # Replication
-hostssl replication     replicator      {{ psf_internal }}      md5
+host replication       replicator       0.0.0.0/0               md5
 
 # Application Databases
-hostssl monitoring        monitoring       {{ psf_internal }}   md5
-hostssl bugs-python       bugs-python      {{ psf_internal }}   md5
-hostssl pydotorg-prod     pydotorg-prod    {{ psf_internal }}   md5
-hostssl pydotorg-staging  pydotorg-staging {{ psf_internal }}   md5
-hostssl pydotorg-staging2 pydotorg-staging {{ psf_internal }}   md5
-hostssl pycon-prod        pycon-prod       {{ psf_internal }}   md5
-hostssl pycon-staging     pycon-staging    {{ psf_internal }}   md5
-hostssl testpypi          testpypi         {{ pypi_internal }}  md5
+host monitoring        monitoring       0.0.0.0/0               md5
+host bugs-python       bugs-python      0.0.0.0/0               md5
+host pydotorg-prod     pydotorg-prod    0.0.0.0/0               md5
+host pydotorg-staging  pydotorg-staging 0.0.0.0/0               md5
+host pydotorg-staging2 pydotorg-staging 0.0.0.0/0               md5
+host pycon-prod        pycon-prod       0.0.0.0/0               md5
+host pycon-staging     pycon-staging    0.0.0.0/0               md5
+host testpypi          testpypi         0.0.0.0/0               md5

--- a/salt/postgresql/server/configs/postgresql.conf.jinja
+++ b/salt/postgresql/server/configs/postgresql.conf.jinja
@@ -46,17 +46,16 @@ external_pid_file = '{{ postgresql.pid_file }}'
 
 # - Connection Settings -
 
-listen_addresses = 'localhost,{{ salt["network.ip_addrs"](cidr=psf_internal)[0] }},{{ salt["network.ip_addrs"](cidr=pypi_internal)[0] }}'
+listen_addresses = 'localhost'
 port = {{ postgresql.port }}
 max_connections = {{ postgresql.max_connections }}
 unix_socket_directories = '/var/run/postgresql'
 
 # - Security and Authentication -
 
-ssl = true
-ssl_ciphers = '{{ pillar["tls"]["ciphers"].get("postgresql", pillar["tls"]["ciphers"]["default"]) }}'
-ssl_cert_file = '/etc/ssl/private/postgresql.psf.io.pem'
-ssl_key_file = '/etc/ssl/private/postgresql.psf.io.pem'
+# We offload TLS handling to stunnel.
+ssl = false
+
 
 
 #------------------------------------------------------------------------------

--- a/salt/postgresql/server/configs/postgresql.conf.jinja
+++ b/salt/postgresql/server/configs/postgresql.conf.jinja
@@ -46,8 +46,8 @@ external_pid_file = '{{ postgresql.pid_file }}'
 
 # - Connection Settings -
 
-listen_addresses = 'localhost'
-port = {{ postgresql.port }}
+listen_addresses = 'localhost,{{ salt["network.ip_addrs"](cidr=psf_internal)[0] }}'
+port = {{ postgresql.port - 1 }}
 max_connections = {{ postgresql.max_connections }}
 unix_socket_directories = '/var/run/postgresql'
 
@@ -55,7 +55,6 @@ unix_socket_directories = '/var/run/postgresql'
 
 # We offload TLS handling to stunnel.
 ssl = false
-
 
 
 #------------------------------------------------------------------------------

--- a/salt/postgresql/server/configs/stunnel.conf.jinja
+++ b/salt/postgresql/server/configs/stunnel.conf.jinja
@@ -3,15 +3,13 @@
 
 pid = /var/run/stunnel/postgresql.pid
 
-
-{% for addr in salt["network.ip_addrs"]() %}
-[postgres-{{ loop.index }}]
+[postgres]
 client = no
-accept = {{ addr }}:{{ postgresql.port }}
-connect = 127.0.0.1:{{ postgresql.port }}
+accept = {{ postgresql.port }}
+connect = {{ salt["network.ip_addrs"](cidr=psf_internal)[0] }}:{{ postgresql.port - 1 }}
+transparent = source
 protocol = pgsql
 cert = /etc/ssl/private/postgresql.psf.io.pem
 key = /etc/ssl/private/postgresql.psf.io.pem
 ciphers = {{ pillar["tls"]["ciphers"].get("postgresql", pillar["tls"]["ciphers"]["default"]) }}
 sslVersion = TLSv1.2
-{% endfor %}

--- a/salt/postgresql/server/configs/stunnel.conf.jinja
+++ b/salt/postgresql/server/configs/stunnel.conf.jinja
@@ -1,0 +1,17 @@
+{% set postgresql = salt["pillar.get"]("postgresql") %}
+{% set psf_internal = salt["pillar.get"]("psf_internal_network") %}
+
+pid = /var/run/stunnel/postgresql.pid
+
+
+{% for addr in salt["network.ip_addrs"]() %}
+[postgres-{{ loop.index }}]
+client = no
+accept = {{ addr }}:{{ postgresql.port }}
+connect = 127.0.0.1:{{ postgresql.port }}
+protocol = pgsql
+cert = /etc/ssl/private/postgresql.psf.io.pem
+key = /etc/ssl/private/postgresql.psf.io.pem
+ciphers = {{ pillar["tls"]["ciphers"].get("postgresql", pillar["tls"]["ciphers"]["default"]) }}
+sslVersion = TLSv1.2
+{% endfor %}

--- a/salt/postgresql/server/if-up.sh
+++ b/salt/postgresql/server/if-up.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "$IFACE" = lo ]; then
+    ip rule add fwmark 1 lookup 100
+    ip route add local 0.0.0.0/0 dev lo table 100
+fi

--- a/salt/postgresql/server/init.sls
+++ b/salt/postgresql/server/init.sls
@@ -10,6 +10,7 @@ This Does Not Support Multi Data Disk Servers!!!!
 {% endif %}
 
 include:
+  - stunnel
   - monitoring.client.collectors.postgresql
   - postgresql.base
 {% if salt["match.compound"](pillar["roles"]["postgresql-primary"]) %}
@@ -68,7 +69,6 @@ postgresql-server:
       - cmd: consul-template
       {% endif %}
     - watch:
-      - file: /etc/ssl/private/postgresql.psf.io.pem
       - file: {{ postgresql.config_file }}
       - file: {{ postgresql.ident_file }}
       - file: {{ postgresql.hba_file }}
@@ -172,6 +172,17 @@ postgresql-psf-cluster:
     - require:
       - cmd: postgresql-psf-cluster
       - file: {{ postgresql.config_dir }}
+
+
+/etc/stunnel/postgresql.conf:
+  file.managed:
+    - source: salt://postgresql/server/configs/stunnel.conf.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pkg: stunnel
 
 
 {% if salt["match.compound"](pillar["roles"]["postgresql-primary"]) %}

--- a/salt/postgresql/server/init.sls
+++ b/salt/postgresql/server/init.sls
@@ -174,6 +174,19 @@ postgresql-psf-cluster:
       - file: {{ postgresql.config_dir }}
 
 
+/etc/network/if-up.d/stunnel:
+  file.managed:
+    - source: salt://postgresql/server/if-up.sh
+    - user: root
+    - group: root
+    - mode: 750
+
+  cmd.wait:
+    - name: IFACE=lo /etc/network/if-up.d/stunnel
+    - watch:
+      - file: /etc/network/if-up.d/stunnel
+
+
 /etc/stunnel/postgresql.conf:
   file.managed:
     - source: salt://postgresql/server/configs/stunnel.conf.jinja

--- a/salt/stunnel/configs/default.sh
+++ b/salt/stunnel/configs/default.sh
@@ -1,0 +1,11 @@
+# /etc/default/stunnel
+# Julien LEMOINE <speedblue@debian.org>
+# September 2003
+
+# Change to one to enable stunnel automatic startup
+ENABLED=1
+FILES="/etc/stunnel/*.conf"
+OPTIONS=""
+
+# Change to one to enable ppp restart scripts
+PPP_RESTART=0

--- a/salt/stunnel/init.sls
+++ b/salt/stunnel/init.sls
@@ -1,0 +1,26 @@
+stunnel:
+  pkg.installed:
+    - pkgs:
+      - stunnel
+
+  user.present:
+    - name: stunnel
+    - system: True
+
+  file.managed:
+    - name: /etc/default/stunnel
+    - source: salt://stunnel/configs/default.sh
+    - require:
+      - pkg: stunnel
+
+  service.running:
+    - name: stunnel
+    - enable: True
+    - reload: True
+    - require:
+      - pkg: stunnel
+      - user: stunnel
+    - watch:
+      - file: /etc/default/stunnel
+      - file: /etc/stunnel/*.conf
+      - file: /etc/ssl/private/*.pem


### PR DESCRIPTION
PostgreSQL doesn't offer the ability to gracefully reload the TLS certificate, which requires a hard restart whenever the certificate is close to expiring. This generates errors because it interrupts current connections. Instead, we'll utilize stunnel to terminate TLS which does support a graceful reload.

We'll also rely on iptables able to mangle packets to spoof the source address on the packets sent from stunnel to PostgreSQL so that PostgreSQL still sees the correct IP address. However, PostgreSQL does not understand that the connections are happening via TLS so things like ``hostssl`` doesn't work. Stunnel will not allow a connection that does not use TLS though, so the rule is still effectively there.

This also relaxes the firewall and what IP addresses we bind the PostgreSQL server too which will enable connections from outside of the Rackspace infrastructure.

Finally, since we can now safely reload certificates without a full restart of PostgreSQL, we'll go ahead and lower the time the database certificate is valid back down to the default of 1 day instead of 7 days.