### PR TITLE
Make sure git is installed for dstufft's dotfiles

### DIFF
--- a/salt/users/dotfiles/dstufft.sls
+++ b/salt/users/dotfiles/dstufft.sls
@@ -1,3 +1,6 @@
+git:
+  pkg.installed
+
 https://github.com/dstufft/dotfiles.git:
   git.latest:
     - target: /home/psf-users/dstufft/.dotfiles
@@ -6,6 +9,7 @@ https://github.com/dstufft/dotfiles.git:
     - force_checkout: True
     - require:
       - sls: users
+      - pkg: git
 
 /home/psf-users/dstufft/.zshenv:
   file.symlink:


### PR DESCRIPTION
Currently bringing up a Vagrant VM fails with 'KeyError: git.latest', this seems to fix it.