### PR TITLE
Redirect docs.p.o/tut/ to the Python 3 tutorial

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -79,7 +79,7 @@ server {
         return 301 https://$host/library/;
     }
     location = /tut/ {
-        return 301 https://$host/tutorial/;
+        return 301 https://$host/3/tutorial/;
     }
     location = /api/ {
         return 301 https://$host/c-api/;


### PR DESCRIPTION
Apparently, the old URL scheme still in use in the internet. See
https://github.com/python/pythondotorg/issues/884 for example.

I might better to redirect http://docs.python.org/tut/ to the Python 3
tutorial at this point.