### PR TITLE
Redirect toplevel URIs to Python 3 docs

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -56,12 +56,12 @@ server {
         return 301 https://$host/devguide/documenting.html#building-the-documentation;
     }
 
-    # Map toplevel URIs to Python 2 docs.
+    # Map toplevel URIs to Python 3 docs.
     location ~ ^/((archives|c-api|distutils|extending|faq|howto|install|library|reference|tutorial|using|whatsnew|_images|_sources|_static)(/.*)?)$ {
-        return 301 https://$host/2/$1;
+        return 301 https://$host/3/$1;
     }
     location ~ ^/(about|bugs|contents|copyright|download|genindex.*|glossary|index|license|py-modindex|search).html$ {
-        return 301 https://$host/2/$1.html;
+        return 301 https://$host/3/$1.html;
     }
     location ~ ^/(searchindex.js|objects.inv)$ {
         return 301 https://$host/2/$1;
@@ -79,7 +79,7 @@ server {
         return 301 https://$host/library/;
     }
     location = /tut/ {
-        return 301 https://$host/3/tutorial/;
+        return 301 https://$host/tutorial/;
     }
     location = /api/ {
         return 301 https://$host/c-api/;


### PR DESCRIPTION
I saw complaints about this on Reddit and Hacker News before.

Here is the latest one: https://asmeurer.github.io/blog/posts/moving-away-from-python-2/#fn:core