### PR TITLE
clone peps from GitHub

### DIFF
--- a/salt/pydotorg/init.sls
+++ b/salt/pydotorg/init.sls
@@ -11,6 +11,7 @@ pydotorg-deps:
   pkg.installed:
     - pkgs:
       - build-essential
+      - git
       - libpq-dev
       - libxml2-dev
       - libxslt-dev
@@ -203,7 +204,7 @@ pydotorg:
 
 check-out-peps:
   cmd.run:
-    - name: hg clone https://hg.python.org/peps /srv/pydotorg/peps
+    - name: git clone https://github.com/python/peps.git /srv/pydotorg/peps
     - user: pydotorg
     - creates: /srv/pydotorg/peps
     - require:

--- a/salt/pydotorg/init.sls
+++ b/salt/pydotorg/init.sls
@@ -15,7 +15,6 @@ pydotorg-deps:
       - libpq-dev
       - libxml2-dev
       - libxslt-dev
-      - mercurial
       - python-docutils
       - python-virtualenv
       - python3-dev


### PR DESCRIPTION
Please do not accept this PR until the peps repository has been migrated to GitHub. Creating this PR now to get a code review that it's accurate for when it's time to do the actual migration.