### PR TITLE
Enable a simple read-only FTP server on pythontest

### DIFF
--- a/pillar/base/firewall/ftp.sls
+++ b/pillar/base/firewall/ftp.sls
@@ -1,0 +1,5 @@
+firewall:
+  ftp:
+    port: 21
+  ftp-incoming:
+    raw: -A INPUT -p tcp --destination-port 10090:10100 -j ACCEPT

--- a/pillar/prod/top.sls
+++ b/pillar/prod/top.sls
@@ -138,6 +138,7 @@ base:
   'pythontest':
     - match: nodegroup
     - firewall.http
+    - firewall.ftp
 
   'salt-master':
     - match: nodegroup

--- a/salt/pythontest/config/vsftpd.conf
+++ b/salt/pythontest/config/vsftpd.conf
@@ -1,0 +1,51 @@
+ftpd_banner=Welcome to the pythontest FTP server
+
+# Run vsftp as a standalone server
+listen=YES
+
+# Allow anonymous FTP. (This is what the test suite uses)
+anonymous_enable=YES
+
+# Use nobody as the FTP user for least privelege
+ftp_username=nobody
+
+# Use the ftp folder from the git repo as the root
+anon_root=/srv/python-testdata/ftp
+
+# The only local users are the python infra team and they
+# do not use ftp for administration
+local_enable=NO
+
+# This option prevents any writing ftp commands from being issued
+write_enable=NO
+
+# Activate directory messages - messages given to remote users when they
+# go into a certain directory.
+dirmessage_enable=YES
+
+# If enabled, vsftpd will display directory listings with the time
+# in  your  local  time  zone.  The default is to display GMT. The
+# times returned by the MDTM FTP command are also affected by this
+# option.
+use_localtime=YES
+
+# Activate logging of uploads/downloads.
+xferlog_enable=YES
+
+# Make sure PORT transfer connections originate from port 20 (ftp-data).
+connect_from_port_20=YES
+# These ports must be opened in the firewall to enable data transfer
+pasv_enable=YES
+pasv_addr_resolve=YES
+pasv_address=www.pythontest.net
+pasv_max_port=10100
+pasv_min_port=10090
+
+# This option should be the name of a directory which is empty.  Also, the
+# directory should not be writable by the ftp user. This directory is used
+# as a secure chroot() jail at times vsftpd does not require filesystem
+# access.
+secure_chroot_dir=/var/run/vsftpd/empty
+
+# Disable PAM support
+session_support=NO

--- a/salt/pythontest/init.sls
+++ b/salt/pythontest/init.sls
@@ -4,6 +4,18 @@ include:
 git:
   pkg.installed
 
+vsftpd:
+  pkg:
+    - installed
+  service.running:
+    - enable: True
+    - restart: True
+    - watch:
+      - file: /etc/vsftpd.conf
+    - require:
+      - file: /etc/vsftpd.conf
+      - pkg: vsftpd
+
 /srv/:
   file.directory:
     - user: www-data
@@ -26,6 +38,12 @@ chmod-testdata:
     - onchanges:
       - git: testdata-repo
 
+chmod-ftpdata:
+  cmd.run:
+    - name: chmod -R a-w /srv/python-testdata/ftp
+    - onchanges:
+      - git: testdata-repo
+
 /etc/nginx/sites.d/pythontest.conf:
   file.managed:
     - source: salt://pythontest/config/nginx.pythontest.conf.jinja
@@ -36,3 +54,10 @@ chmod-testdata:
   require:
     - file: /etc/nginx/sites.d/
     - git: testdata-repo
+
+/etc/vsftpd.conf:
+  file.managed:
+    - source: salt://pythontest/config/vsftpd.conf
+    - user: root
+    - group: root
+    - mode: 644


### PR DESCRIPTION
This is my first time using salt, though not my first time using an orchestration tool. I tested locally on an ubuntu-14.04 server VM. I'd appreciate any feedback if I made any glaring mistakes.

## Technical Details:
This installs and configures the vsftpd package. The running server is configured to only allow anonymous logins, all write commands are disabled at the ftp dameon level. See the `write_enable=False` option, in addition to setting the ftp folder to be `-w` by all. This makes it so that the entire ftp server is read-only. 

In order to allow ftp through the firewall I've used ports 10090 to 10100, ftp needs to have open incoming ports to allow for data transfers. The alternative to using these fixed ports is to use a kernel module that hooks into iptables and snoops on ftp connections to dynamically allow them through. See here for more details: https://serverfault.com/a/38425

Aside from that the only notable thing this does is change the home of the ftp user to one pointed in the git repo, this makes it so that files can be added to the ftp server automatically as they're pulled from git. Hence, this associated pull request in the pythontestdotnet repo should be pulled before this:  https://github.com/python/pythontestdotnet/pull/1

## Why:
Currently the python test suite uses the debian.org FTP servers for testing, however those will be shutting down soon: https://www.debian.org/News/2017/20170425

See the following bug.python.org threads and github issues:

- https://bugs.python.org/issue30883
- http://bugs.python.org/issue22650
- https://github.com/python/pythondotorg/issues/1069