### PR TITLE
Redirect root of translations (like /fr/) to their 3 version

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -21,6 +21,11 @@ server {
         return 302 $scheme://$host/3/;
     }
 
+    # Python 3 docs are the default at the root of each translations.
+    location ~ ^/(fr)/$ {
+        return 302 $scheme://$host/$1/3/;
+    }
+
     # Some doc download pages link to docs.python.org/ftp instead of www.python.org/ftp.
     location /ftp/ {
         return 301 https://www.python.org$request_uri;


### PR DESCRIPTION
Currently https://docs.python.org/fr/ gives a directory listing. As / is redirecting to /3/, I'm also redirecting /fr/ to /fr/3/.

