### PR TITLE
docs.python.org: Add Japanese in nginx redirections.

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -22,7 +22,7 @@ server {
     }
 
     # Python 3 docs are the default at the root of each translations.
-    location ~ ^/(fr)/$ {
+    location ~ ^/(fr|ja)/$ {
         return 302 $scheme://$host/$1/3/;
     }
 


### PR DESCRIPTION
https://docs.python.org/ja/3.6/ is successfully build, now needs the redirection to avoid directory listing on https://docs.python.org/ja/.