### PR TITLE
Set x-xss-protection header on pydotorg

### DIFF
--- a/salt/pydotorg/config/pydotorg.nginx.jinja
+++ b/salt/pydotorg/config/pydotorg.nginx.jinja
@@ -11,6 +11,8 @@ server {
 
   error_log /var/log/nginx/pydotorg.error.log;
   access_log /var/log/nginx/pydotorg.access.log;
+  
+  add_header x-xss-protection "1; mode=block" always;
 
   # Legacy redirects & Rewrites from dinsdale apache
   location ~ ^/~(barry|bwarsaw)$ {


### PR DESCRIPTION
I don't know whether https://github.com/python/psf-salt/blob/master/salt/haproxy/config/haproxy.cfg.jinja is a better place to put this so I went with `salt/pydotorg/config/pydotorg.nginx.jinja`.