### PR TITLE
docsbuild-scripts: Dropping now default --git flag

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -89,7 +89,7 @@ py36-virtualenv-dependencies:
 docsbuild-full:
   cron.present:
     - identifier: docsbuild-full
-    - name: python3 /srv/docsbuild/scripts/build_docs.py --git
+    - name: python3 /srv/docsbuild/scripts/build_docs.py
     - user: docsbuild
     - minute: 7
     - hour: 0
@@ -99,7 +99,7 @@ docsbuild-full:
 docsbuild-quick:
   cron.present:
     - identifier: docsbuild-quick
-    - name: python3 /srv/docsbuild/scripts/build_docs.py -q --git
+    - name: python3 /srv/docsbuild/scripts/build_docs.py -q
     - user: docsbuild
     - minute: 7
     - hour: 2-23/3


### PR DESCRIPTION
Since https://github.com/python/docsbuild-scripts/commit/c7181345d6735f6315f522a97ccb3031d320f08c which is already deployed, the --git flag is the default.