### PR TITLE
Set CSRF_TRUSTED_ORIGINS for staging.p.o

### DIFF
--- a/salt/pydotorg/config/django-settings.py.jinja
+++ b/salt/pydotorg/config/django-settings.py.jinja
@@ -63,6 +63,7 @@ FASTLY_API_KEY = '{{ pillar["fastly"]["api_key"] }}'
 {% if type == "staging" %}
 
 CSRF_COOKIE_DOMAIN = '{{ name }}.python.org'
+CSRF_TRUSTED_ORIGINS = ['{{ name }}.python.org']
 SESSION_COOKIE_DOMAIN = '{{ name }}.python.org'
 
 {% else %}


### PR DESCRIPTION
We need to set this on staging.p.o because the is_same_domain() function
returns true only when the hostname of the referer is an exact match of
CSRF_COOKIE_DOMAIN.

In our case it returns false because "staging.python.org" is not an
equivalent of "staging.python.org:9000" and as a result we get a 403 error.

See https://github.com/django/django/blob/e7adad27f30396823f3609fcb8699cefb25278bb/django/middleware/csrf.py#L273
for details.