### PR TITLE
Add xelatex to help building french PDFs.

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -21,6 +21,7 @@ doc-pkgs:
       - texlive-latex-recommended
       - texlive-fonts-recommended
       - texlive-lang-all
+      - texlive-xetex
       - zip
     - require:
       - pkgrepo: deadsnakes-ppa


### PR DESCRIPTION
xelatex has better Unicode support than pdflatex, sufficient to build
french, but not to build japanese. But we already have platex, capable
to build japanese, installed from texlive-lang-japanese pulled as a
dependency of texlive-lang-all.

See:

- https://github.com/sphinx-doc/sphinx/issues/4136
- https://github.com/python/cpython/pull/3940