### PR TITLE
FIX 301 to the new devguide.

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -36,7 +36,7 @@ server {
     }
 
     # Map /documenting to the devguide.
-    location = /devguide/(*) {
+    location ~ ^/devguide/(.*)$ {
         return 301 https://devguide.python.org/$1;
     }
     location = /documenting/ {


### PR DESCRIPTION
The old configuration was redirecting only for:

curl -I 'https://docs.python.org/devguide/(*)'

See https://bugs.python.org/issue30737