### PR TITLE
Redirect /searchindex.js and /objects.inv to /3/

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -72,7 +72,7 @@ server {
         return 301 https://$host/3/$1.html;
     }
     location ~ ^/(searchindex.js|objects.inv)$ {
-        return 301 https://$host/2/$1;
+        return 301 https://$host/3/$1;
     }
 
     # Emulate Apache's content-negotiation. Probably should remove eventually.


### PR DESCRIPTION
This was reported at https://twitter.com/zzzeek/status/963804209618571264