### PR TITLE
Install libjpeg-dev for Pillow

### DIFF
--- a/salt/pydotorg/init.sls
+++ b/salt/pydotorg/init.sls
@@ -15,6 +15,7 @@ pydotorg-deps:
       - libpq-dev
       - libxml2-dev
       - libxslt-dev
+      - libjpeg-dev
       - python3-docutils
       - python-virtualenv
       - python3-dev


### PR DESCRIPTION
We've upgraded Pillow version to 5.1.0 in
https://github.com/python/pythondotorg/commit/21ecdc2289e4f4b64b936394bd3f1c5171f6bd73

Pillow requires JPEG support since 3.x so we need to
install libjpeg-dev.