### PR TITLE
Adding configuration for zh-{cn,tw} translation of the documentation

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -22,7 +22,7 @@ server {
     }
 
     # Python 3 docs are the default at the root of each translations.
-    location ~ ^/(fr|ja|ko)/$ {
+    location ~ ^/(fr|ja|ko|zh-cn|zh-tw)/$ {
         return 302 $scheme://$host/$1/3/;
     }
 


### PR DESCRIPTION
docs.python.org/zh-{cn,tw} are available now.