### PR TITLE
Docs: Directly jump in venv to get sentry.

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -87,7 +87,7 @@ docsbuild-sentry:
 docsbuild-full:
   cron.present:
     - identifier: docsbuild-full
-    - name: python3 /srv/docsbuild/scripts/build_docs.py
+    - name: /srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py
     - user: docsbuild
     - minute: 7
     - hour: 0
@@ -97,7 +97,7 @@ docsbuild-full:
 docsbuild-quick:
   cron.present:
     - identifier: docsbuild-quick
-    - name: python3 /srv/docsbuild/scripts/build_docs.py -q
+    - name: /srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py -q
     - user: docsbuild
     - minute: 7
     - hour: 2-23/3


### PR DESCRIPTION
By just using the global Python we're not having sentry installed.

But using the venv directly is fine: we'll get sentry, and it would simplify passing the venv to subprocesses. Which is supported down to the Makefile since https://github.com/python/cpython/commit/590665c399fc4aa3c4a9f8e7104d43a02e9f3a0c#diff-c8dee9c3c068ad3447bbf459950a35b5 which is nice.