### PR TITLE
Smooth the switch between sets.html and stdtypes.html

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -35,6 +35,11 @@ server {
         return 301 https://$host/3$1;
     }
 
+    # Smooth the switch between versions by mapping old files to their new location
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8)/library/sets.html$ {
+        return 301 https://$host/$1$2/library/stdtypes.html#set-types-set-frozenset;
+    }
+
     # Map /documenting to the devguide.
     location ~ ^/devguide/(.*)$ {
         return 301 https://devguide.python.org/$1;

--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -39,6 +39,9 @@ server {
     location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8)/library/sets.html$ {
         return 301 https://$host/$1$2/library/stdtypes.html#set-types-set-frozenset;
     }
+    location ~ ^/([a-z-]*/)?(3|3.6|3.7|3.8)/library/email.util.html$ {
+        return 301 https://$host/$1$2/library/email.utils.html;
+    }
 
     # Map /documenting to the devguide.
     location ~ ^/devguide/(.*)$ {


### PR DESCRIPTION
On the backend we're having ~100 hits per day on */library/sets.html. This is (behind some "/apple-touch-icon.png" and co.) the most frequent 404 on the docs.

Those are people searching "sets" on search engines, landing on https://docs.python.org/2/library/sets.html, changing the version on the version switcher. At this moment the switcher script tries to hit the URL and get a 404 (this page no longer exist on new versions), so the script redirects the user on /, which is ... as not as helpfull as it can be.