### PR TITLE
Docs: Will probably never remove this one.

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -75,7 +75,8 @@ server {
         return 301 https://$host/3/$1;
     }
 
-    # Emulate Apache's content-negotiation. Probably should remove eventually.
+    # Emulate Apache's content-negotiation. Was a temporary measure,
+    # but now people are using it like a feature.
     location ~ ^/((2|3)(\.[0-8])?|dev)/\w+/[\d\w\.]+(?!\.html)$ {
         if (-f "${request_filename}.html") {
             return 301 https://$host:$request_uri.html;


### PR DESCRIPTION
We're having like 100 hits per day on this one according to ```zcat /var/log/nginx/docs-backend.access.log.{2..7}.gz | awk '{if ($9 == 301) {print $7}}' | grep -P '^/((2|3)(\.[0-8])?|dev)/\w+/[\d\w\.]+(?!\.html)$' | wc -l```

Some are bots, some are humans using it as a feature (maybe like 1 of 2).