### PR TITLE
Doc: Missing latexmk dependency

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -16,6 +16,7 @@ doc-pkgs:
       - python-dev
       - python3.6-dev
       - python-virtualenv
+      - latexmk
       - texlive
       - texlive-latex-extra
       - texlive-latex-recommended


### PR DESCRIPTION
Seen this in the logs of zh_TW:

```
latexmk -r latexmkjarc -pdfdvi -dvi- -ps-  'howto-curses.tex'
make[3]: latexmk: Command not found
```