### PR TITLE
Doc: Missing latexmk dependency

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -10,6 +10,7 @@ doc-pkgs:
       - mercurial
       - python-dev
       - python-virtualenv
+      - latexmk
       - texlive
       - texlive-latex-extra
       - texlive-latex-recommended


### PR DESCRIPTION
rebase of #160 on the 18.04 universe branch.