### PR TITLE
Doc: Missing xindy dependency.

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -17,6 +17,7 @@ doc-pkgs:
       - texlive-fonts-recommended
       - texlive-lang-all
       - texlive-xetex
+      - xindy
       - zip
 
 docsbuild:


### PR DESCRIPTION
Looks like we're missing this dependency, from the logs I see:
```
Can't exec "xindy": No such file or directory at (eval 10) line 14.
```
