### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: python
 
-sudo: false
+cache: pip
 
-cache:
-  - pip
-
-env:
-  - TOXENV=docs
+env: TOXENV=docs
 
 install: pip install tox
 


### PR DESCRIPTION
Fixes #170  [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_" 