### PR TITLE
Allow schlatterbeck access to roundup tracker

### DIFF
--- a/pillar/base/users.sls
+++ b/pillar/base/users.sls
@@ -379,3 +379,14 @@ users:
         allowed: True
         groups:
           - roundup
+
+  schlatterbeck:
+    fullname: "Ralf Schlatterbeck"
+    ssh_keys:
+      - ssh-rsa ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDWL8ig6kjtktAzMKnDkeKdUm1Su/wLIG9knKHEc/pgEy8Z4SZD6Q40oYHIqyeTr5LSupQd9BUn4A2cAWq/ZdplOH6n2T6DqG5wZ0hQlCmxUl4OHoTDyijdxsqk3n9YF+TC3bwsSt7OfRE2we5AL8NLwneGffV4PrYqKQIOTjrSa4S29KIHW+burBqOFFzWiw3ejU1Bwb3n4PlJJ0ceFfbM2ox8OKbN0SvsfviCnzuAszjd77EzF2pFZzWaqA5ur7Yp+EAIR1ENHyMw/1X/do8X5jwgBrA126HfSj2Ns/3PZT4QNLoiXyxN7eeO7sHsfE1s36I3qR71Q0UzDP4g7p3tZ3SrcA+NwVhQauyYX2mwRU6APUyrboeMXYHPQYiXH0zaOSHZCMr5GP70n409pzsQDOSj/F+QUMQes3Uq8CJILGzY8xGmTYV6rY48oHdnNu63rbeSwuMAoYH945eVkEAQy6z32oPmJw/YBoTQmLC0fZNPAmxZGEkqWQktrUKK092/g57IS+k0JC1ZKK2OdFH2WhCerNGnM57iGhWkjavorhHtDsIh0RQ34YSAInsmyuMGXtHxcLGzi5iHfIpFH4on9iEqcez7CoPIGKYh3u3mvXYclWEpU/JvEfNf9bzI3m0rXM0zRYyVBk5g1hZWL89PSDOYqB3hZef2/EAiihycqQ== rsc@runtux.com
+    access:
+      bugs:
+        sudo: True
+        allowed: True
+        groups:
+          - roundup


### PR DESCRIPTION
Used to have shell access to old bugs.python.org, we recently had a spam event where I wrote a spam removal script, in this case John Rouillard already removed the spam but there will be others.