### PR TITLE
Docs: Remove quick cron: on version bumps they cause 404s.

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -91,7 +91,7 @@ docsbuild-full:
       - cmd: virtualenv-dependencies
 
 docsbuild-quick:
-  cron.present:
+  cron.absent:
     - identifier: docsbuild-quick
     - name: /srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py -q
     - user: docsbuild


### PR DESCRIPTION
see https://github.com/python/docsbuild-scripts/issues/68

Also I don't think it's usefull to have docs updated every 3 hours, apart from /dev/, they change very slowly.

Also now that we have translations, it's not 6 versions that we're building but 6 versions × 6 languages, it starts to be CPU heavy.

I'm sure we can do better, but in the meantime it should fix 404s that we're getting on every releases.