### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/salt/hg/files/hg/src/hglookup.py
+++ b/salt/hg/files/hg/src/hglookup.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # hglookup.py
 #
 # Lookup a revision hash in a bunch of different hgwebdir repos.
@@ -7,6 +6,8 @@ from __future__ import print_function
 #
 # Written by Georg Brandl, 2010.
 # Updated by Brett Cannon, 2017.
+
+from __future__ import print_function
 
 import io
 import json

--- a/salt/hg/files/hg/src/hglookup.py
+++ b/salt/hg/files/hg/src/hglookup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # hglookup.py
 #
 # Lookup a revision hash in a bunch of different hgwebdir repos.
@@ -56,7 +57,7 @@ class hglookup(object):
 
 if __name__ == '__main__':
     HG_COMMITS = 'hg_commits.json'
-    print "Loading hg commits from the JSON file ..."
+    print("Loading hg commits from the JSON file ...")
     # Use `hg log --template "\"{node}\",\n` to help generate the JSON file.
     with io.open(HG_COMMITS, 'r', encoding="utf-8") as file:
         hg_commits = json.load(file)
@@ -64,5 +65,5 @@ if __name__ == '__main__':
 
     httpd = make_server('', 8123, application)
     sa = httpd.socket.getsockname()
-    print "Serving HTTP on", sa[0], "port", sa[1], "..."
+    print("Serving HTTP on", sa[0], "port", sa[1], "...")
     httpd.serve_forever()


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.