### PR TITLE
docsbuild-scripts: Make python3 -m venv work.

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -11,6 +11,7 @@ doc-pkgs:
       - mercurial
       - python-dev
       - python-virtualenv
+      - python3-venv
       - latexmk
       - texinfo
       - texlive


### PR DESCRIPTION
This is in case I finish a current implementation where docsbuild-scripts manage its venv itself.

It could be a good thing: allowing to have multiple venvs, with multiple versions of sphinx, thus allowing to still buid old versions of Python which do no longer build with current sphinx.

Eventually, I hope to reach a cleaner state where:
 - docsbuild-script's requirements are only its own requirements (mostly sentry)
 - it handles build requirements itself (`jeiba`, `sphinx`, `blurb`, `python-docs-theme` ...)

Currently both are mixed in the requirements.txt file.
