### PR TITLE
Doc: Hello Python 3.9 and 3.10.

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -85,7 +85,7 @@ server {
 
     # Emulate Apache's content-negotiation. Was a temporary measure,
     # but now people are using it like a feature.
-    location ~ ^/((2|3)(\.[0-8])?|dev)/\w+/[\d\w\.]+(?!\.html)$ {
+    location ~ ^/((2|3)(\.[0-9]+)?|dev)/\w+/[\d\w\.]+(?!\.html)$ {
         if (-f "${request_filename}.html") {
             return 301 https://$host:$request_uri.html;
         }


### PR DESCRIPTION
Related to https://bugs.python.org/issue42869

This should make `https://docs.python.org/3.9/library/functions` redirect like `https://docs.python.org/3.8/library/functions` does.

Currently:
```
$ curl -i https://docs.python.org/3.8/library/functions | head -n 1
HTTP/2 301 

$ curl -i https://docs.python.org/3.9/library/functions | head -n 1
HTTP/2 404 
```

Beware, I did *not* tested it locally.
