### PR TITLE
Redirect all 2.7 files removed in Python 3

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -39,106 +39,106 @@ server {
     location ~ ^/([a-z-]*/)?(3|3.6|3.7|3.8)/library/email.util.html$ {
         return 301 https://$host/$1$2/library/email.utils.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/c-api/(class|cobject|int|string).html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/c-api/(class|cobject|int|string).html$ {
         return 301 https://$host/$1$2/;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/howto/(doanddont|webservers).html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/howto/(doanddont|webservers).html$ {
         return 301 https://$host/$1$2/;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/(aepack|aetools|aetypes|al|autogil|bastion|bsddb|carbon|cd|colorpicker|commands|compiler|dbhash|dircache|dl|dummy_thread|easydialogs|fl|fm|fpectl|fpformat|framework|future_builtins|gensuitemodule|gl|hotshot|htmllib|ic|imageop|imgfile|imputil|jpeg|mac|macos|macosa|macostools|macpath|md5|mhlib|mimetools|mimewriter|mimify|miniaeframe|multifile|mutex|new|popen2|posixfile|restricted|rexec|rfc822|sgi|sgmllib|sha|someos|statvfs|sun|sunaudio|user).html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/(aepack|aetools|aetypes|al|autogil|bastion|bsddb|carbon|cd|colorpicker|commands|compiler|dbhash|dircache|dl|dummy_thread|easydialogs|fl|fm|fpectl|fpformat|framework|future_builtins|gensuitemodule|gl|hotshot|htmllib|ic|imageop|imgfile|imputil|jpeg|mac|macos|macosa|macostools|macpath|md5|mhlib|mimetools|mimewriter|mimify|miniaeframe|multifile|mutex|new|popen2|posixfile|restricted|rexec|rfc822|sgi|sgmllib|sha|someos|statvfs|sun|sunaudio|user).html$ {
         return 301 https://$host/$1$2/;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/strings.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/strings.html$ {
         return 301 https://$host/$1$2/library/text.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/stringio.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/stringio.html$ {
         return 301 https://$host/$1$2/library/io.html#io.StringIO;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/sets.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/sets.html$ {
         return 301 https://$host/$1$2/library/stdtypes.html#set-types-set-frozenset;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/userdict.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/userdict.html$ {
         return 301 https://$host/$1$2/library/collections.html#userdict-objects;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/repr.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/repr.html$ {
         return 301 https://$host/$1$2/library/reprlib.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/copy_reg.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/copy_reg.html$ {
         return 301 https://$host/$1$2/library/copyreg.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/anydbm.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/anydbm.html$ {
         return 301 https://$host/$1$2/library/dbm.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/whichdb.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/whichdb.html$ {
         return 301 https://$host/$1$2/library/dbm.html#dbm.whichdb;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/dumbdbm.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/dumbdbm.html$ {
         return 301 https://$host/$1$2/library/dbm.html#module-dbm.dumb;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/dbm.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/dbm.html$ {
         return 301 https://$host/$1$2/library/dbm.html#module-dbm.ndbm;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/gdbm.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/gdbm.html$ {
         return 301 https://$host/$1$2/library/dbm.html#module-dbm.gnu;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/robotparser.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/robotparser.html$ {
         return 301 https://$host/$1$2/library/urllib.robotparser.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/thread.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/thread.html$ {
         return 301 https://$host/$1$2/library/_thread.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/email-examples.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/email-examples.html$ {
         return 301 https://$host/$1$2/library/email.examples.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/htmlparser.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/htmlparser.html$ {
         return 301 https://$host/$1$2/library/html.parser.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/urllib2.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/urllib2.html$ {
         return 301 https://$host/$1$2/library/urllib.request.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/httplib.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/httplib.html$ {
         return 301 https://$host/$1$2/library/http.client.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/urlparse.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/urlparse.html$ {
         return 301 https://$host/$1$2/library/urllib.parse.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/basehttpserver.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/basehttpserver.html$ {
         return 301 https://$host/$1$2/library/http.server.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/simplehttpserver.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/simplehttpserver.html$ {
         return 301 https://$host/$1$2/library/http.server.html#http.server.SimpleHTTPRequestHandler;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/cgihttpserver.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/cgihttpserver.html$ {
         return 301 https://$host/$1$2/library/http.server.html#http.server.CGIHTTPRequestHandler;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/cookielib.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/cookielib.html$ {
         return 301 https://$host/$1$2/library/http.cookiejar.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/cookie.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/cookie.html$ {
         return 301 https://$host/$1$2/library/http.cookies.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/xmlrpclib.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/xmlrpclib.html$ {
         return 301 https://$host/$1$2/library/xmlrpc.client.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/simplexmlrpcserver.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/simplexmlrpcserver.html$ {
         return 301 https://$host/$1$2/library/xmlrpc.server.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/docxmlrpcserver.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/docxmlrpcserver.html$ {
         return 301 https://$host/$1$2/library/xmlrpc.server.html#documenting-xmlrpc-server;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/ttk.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/ttk.html$ {
         return 301 https://$host/$1$2/library/tkinter.ttk.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/tix.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/tix.html$ {
         return 301 https://$host/$1$2/library/tkinter.tix.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/scrolledtext.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/scrolledtext.html$ {
         return 301 https://$host/$1$2/library/tkinter.scrolledtext.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/__builtin__.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/__builtin__.html$ {
         return 301 https://$host/$1$2/library/builtins.html;
     }
-    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/_winreg.html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/_winreg.html$ {
         return 301 https://$host/$1$2/library/winreg.html;
     }
 

--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -40,7 +40,7 @@ server {
         return 301 https://$host/$1$2/library/email.utils.html;
     }
     location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/c-api/(class|cobject|int|string).html$ {
-        return 301 https://$host/$1$2/;
+        return 301 https://$host/$1$2/c-api/;
     }
     location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/howto/(doanddont|webservers).html$ {
         return 301 https://$host/$1$2/;

--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -36,11 +36,110 @@ server {
     }
 
     # Smooth the switch between versions by mapping old files to their new location
-    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8)/library/sets.html$ {
-        return 301 https://$host/$1$2/library/stdtypes.html#set-types-set-frozenset;
-    }
     location ~ ^/([a-z-]*/)?(3|3.6|3.7|3.8)/library/email.util.html$ {
         return 301 https://$host/$1$2/library/email.utils.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/c-api/(class|cobject|int|string).html$ {
+        return 301 https://$host/$1$2/;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/howto/(doanddont|webservers).html$ {
+        return 301 https://$host/$1$2/;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/(aepack|aetools|aetypes|al|autogil|bastion|bsddb|carbon|cd|colorpicker|commands|compiler|dbhash|dircache|dl|dummy_thread|easydialogs|fl|fm|fpectl|fpformat|framework|future_builtins|gensuitemodule|gl|hotshot|htmllib|ic|imageop|imgfile|imputil|jpeg|mac|macos|macosa|macostools|macpath|md5|mhlib|mimetools|mimewriter|mimify|miniaeframe|multifile|mutex|new|popen2|posixfile|restricted|rexec|rfc822|sgi|sgmllib|sha|someos|statvfs|sun|sunaudio|user).html$ {
+        return 301 https://$host/$1$2/;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/strings.html$ {
+        return 301 https://$host/$1$2/library/text.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/stringio.html$ {
+        return 301 https://$host/$1$2/library/io.html#io.StringIO;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/sets.html$ {
+        return 301 https://$host/$1$2/library/stdtypes.html#set-types-set-frozenset;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/userdict.html$ {
+        return 301 https://$host/$1$2/library/collections.html#userdict-objects;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/repr.html$ {
+        return 301 https://$host/$1$2/library/reprlib.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/copy_reg.html$ {
+        return 301 https://$host/$1$2/library/copyreg.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/anydbm.html$ {
+        return 301 https://$host/$1$2/library/dbm.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/whichdb.html$ {
+        return 301 https://$host/$1$2/library/dbm.html#dbm.whichdb;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/dumbdbm.html$ {
+        return 301 https://$host/$1$2/library/dbm.html#module-dbm.dumb;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/dbm.html$ {
+        return 301 https://$host/$1$2/library/dbm.html#module-dbm.ndbm;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/gdbm.html$ {
+        return 301 https://$host/$1$2/library/dbm.html#module-dbm.gnu;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/robotparser.html$ {
+        return 301 https://$host/$1$2/library/urllib.robotparser.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/thread.html$ {
+        return 301 https://$host/$1$2/library/_thread.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/email-examples.html$ {
+        return 301 https://$host/$1$2/library/email.examples.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/htmlparser.html$ {
+        return 301 https://$host/$1$2/library/html.parser.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/urllib2.html$ {
+        return 301 https://$host/$1$2/library/urllib.request.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/httplib.html$ {
+        return 301 https://$host/$1$2/library/http.client.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/urlparse.html$ {
+        return 301 https://$host/$1$2/library/urllib.parse.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/basehttpserver.html$ {
+        return 301 https://$host/$1$2/library/http.server.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/simplehttpserver.html$ {
+        return 301 https://$host/$1$2/library/http.server.html#http.server.SimpleHTTPRequestHandler;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/cgihttpserver.html$ {
+        return 301 https://$host/$1$2/library/http.server.html#http.server.CGIHTTPRequestHandler;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/cookielib.html$ {
+        return 301 https://$host/$1$2/library/http.cookiejar.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/cookie.html$ {
+        return 301 https://$host/$1$2/library/http.cookies.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/xmlrpclib.html$ {
+        return 301 https://$host/$1$2/library/xmlrpc.client.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/simplexmlrpcserver.html$ {
+        return 301 https://$host/$1$2/library/xmlrpc.server.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/docxmlrpcserver.html$ {
+        return 301 https://$host/$1$2/library/xmlrpc.server.html#documenting-xmlrpc-server;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/ttk.html$ {
+        return 301 https://$host/$1$2/library/tkinter.ttk.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/tix.html$ {
+        return 301 https://$host/$1$2/library/tkinter.tix.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/scrolledtext.html$ {
+        return 301 https://$host/$1$2/library/tkinter.scrolledtext.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/__builtin__.html$ {
+        return 301 https://$host/$1$2/library/builtins.html;
+    }
+    location ~ ^/([a-z-]*/)?(3(.[0-9]*)?)/library/_winreg.html$ {
+        return 301 https://$host/$1$2/library/winreg.html;
     }
 
     # Map /documenting to the devguide.


### PR DESCRIPTION
See https://github.com/python/cpython/pull/24195 and https://github.com/python/pythondotorg/issues/1719

Also see https://github.com/verhovsky/py3redirect/blob/master/special-cases.js for a list of anchors that have been moved.

Generated using the following code:

```py
moved_files = {
    "library/fpformat": None,
    "library/mutex": None,
    "library/new": None,
    "library/statvfs": None,
    "library/dircache": None,
    "library/macpath": None,
    "library/dbhash": None,
    "library/bsddb": None,
    # "library/someos": "library/index.html",
    "library/someos": None,
    # "library/popen2": "library/subprocess.html",
    "library/popen2": None,
    # "library/mhlib": "library/mailbox.html",
    "library/mhlib": None,
    # "library/mimetools": "library/email.html",
    "library/mimetools": None,
    # "library/mimewriter": "library/email.html",
    "library/mimewriter": None,
    # "library/mimify": "library/email.html",
    "library/mimify": None,
    # "library/multifile": "library/email.html",
    "library/multifile": None,
    "library/sgmllib": None,
    "library/imageop": None,
    # "library/hotshot": "library/profile.html",
    "library/hotshot": None,
    "library/future_builtins": None,
    "library/user": None,
    "library/fpectl": None,
    "library/restricted": None,
    "library/rexec": None,
    "library/bastion": None,
    "library/imputil": None,
    "library/compiler": None,
    # "library/dl": "library/ctypes.html",
    "library/dl": None,
    "library/posixfile": None,
    # "library/commands": "library/subprocess.html",
    "library/commands": None,
    "library/mac": None,
    "library/ic": None,
    "library/macos": None,
    "library/macostools": None,
    "library/easydialogs": None,
    "library/framework": None,
    "library/autogil": None,
    "library/carbon": None,
    "library/colorpicker": None,
    "library/macosa": None,
    "library/gensuitemodule": None,
    "library/aetools": None,
    "library/aepack": None,
    "library/aetypes": None,
    "library/miniaeframe": None,
    "library/sgi": None,
    "library/al": None,
    "library/cd": None,
    "library/fl": None,
    "library/fm": None,
    "library/gl": None,
    "library/imgfile": None,
    "library/jpeg": None,
    "library/sun": None,
    "library/sunaudio": None,
    # "c-api/int": "c-api/long.html",
    "c-api/int": None,
    # "c-api/string": "c-api/bytes.html",
    "c-api/string": None,
    "c-api/class": None,
    # "c-api/cobject": "c-api/capsule.html",
    "c-api/cobject": None,
    "howto/doanddont": None,
    "howto/webservers": None,
    "library/strings": "library/text.html",
    "library/stringio": "library/io.html#io.StringIO",
    # "library/sets": "library/stdtypes.html#set",
    # "library/sets": None,
    "library/sets": "library/stdtypes.html#set-types-set-frozenset",
    "library/userdict": "library/collections.html#userdict-objects",
    "library/repr": "library/reprlib.html",
    "library/copy_reg": "library/copyreg.html",
    "library/anydbm": "library/dbm.html",
    "library/whichdb": "library/dbm.html#dbm.whichdb",
    "library/dumbdbm": "library/dbm.html#module-dbm.dumb",
    "library/dbm": "library/dbm.html#module-dbm.ndbm",
    "library/gdbm": "library/dbm.html#module-dbm.gnu",
    "library/robotparser": "library/urllib.robotparser.html",
    # "library/md5": "library/hashlib.html",
    "library/md5": None,
    # "library/sha": "library/hashlib.html",
    "library/sha": None,
    "library/thread": "library/_thread.html",
    # Renamed to _dummy_thread but has since been removed completely
    # "library/dummy_thread": "library/_dummy_thread.html",
    "library/dummy_thread": None,
    "library/email-examples": "library/email.examples.html",
    # "library/rfc822": "library/email.html",
    "library/rfc822": None,
    "library/htmlparser": "library/html.parser.html",
    "library/htmllib": None,
    # "library/urllib2": "library/urllib.html",
    "library/urllib2": "library/urllib.request.html",
    "library/httplib": "library/http.client.html",
    "library/urlparse": "library/urllib.parse.html",
    "library/basehttpserver": "library/http.server.html",
    "library/simplehttpserver": "library/http.server.html#http.server.SimpleHTTPRequestHandler",
    "library/cgihttpserver": "library/http.server.html#http.server.CGIHTTPRequestHandler",
    "library/cookielib": "library/http.cookiejar.html",
    "library/cookie": "library/http.cookies.html",
    "library/xmlrpclib": "library/xmlrpc.client.html",
    "library/simplexmlrpcserver": "library/xmlrpc.server.html",
    "library/docxmlrpcserver": "library/xmlrpc.server.html#documenting-xmlrpc-server",
    "library/ttk": "library/tkinter.ttk.html",
    "library/tix": "library/tkinter.tix.html",
    "library/scrolledtext": "library/tkinter.scrolledtext.html",
    "library/__builtin__": "library/builtins.html",
    "library/_winreg": "library/winreg.html",
}

deleted_files = {old for old, new in moved_files.items() if new is None}
moved_files = {old: new for old, new in moved_files.items() if new is not None}

from itertools import groupby

LANGUAGE_AND_VERSION = "([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)"

for top_level, old_urls in groupby(sorted(deleted_files), key=lambda x: x.split("/")[0]):
    # print(top_level, list(old_urls))
    filenames = [x.split("/")[1] for x in old_urls]

    print(
        "    location ~ ^/"
        + LANGUAGE_AND_VERSION
        + "/"
        + top_level
        + "/("
        + "|".join(sorted(filenames))
        + ").html$ {"
    )
    print(f"        return 301 https://$host/$1$2/;")
    print("    }")


for old, new in moved_files.items():
    print("    location ~ ^/" + LANGUAGE_AND_VERSION + "/" + old + ".html$ {")
    print(f"        return 301 https://$host/$1$2/{new};")
    print("    }")
```