### PR TITLE
expose get-pip's "public" folder at bootstrap.pypa.io/pip

### DIFF
--- a/salt/pypa/bootstrap/init.sls
+++ b/salt/pypa/bootstrap/init.sls
@@ -87,7 +87,7 @@ virtualenv-clone:
 
 /srv/bootstrap/www/get-pip.py:
   file.symlink:
-    - target: /srv/bootstrap/pip/get-pip.py
+    - target: /srv/bootstrap/pip/public/get-pip.py
     - require:
       - git: pip-clone
 

--- a/salt/pypa/bootstrap/init.sls
+++ b/salt/pypa/bootstrap/init.sls
@@ -77,6 +77,14 @@ virtualenv-clone:
     - require:
       - pkg: bootrap-deps
 
+
+/srv/bootstrap/www/pip:
+  file.symlink:
+    - target: /srv/bootstrap/pip/public
+    - require:
+      - git: pip-clone
+
+
 /srv/bootstrap/www/get-pip.py:
   file.symlink:
     - target: /srv/bootstrap/pip/get-pip.py


### PR DESCRIPTION
see: https://github.com/pypa/get-pip/issues/61