### PR TITLE
move pypy.org base repo to github

### DIFF
--- a/salt/pypy-web/init.sls
+++ b/salt/pypy-web/init.sls
@@ -5,7 +5,7 @@ include:
 pypy-web-deps:
   pkg.installed:
     - pkgs:
-      - mercurial
+      - git
 
 /srv/pypy:
   file.directory:
@@ -23,9 +23,9 @@ pypy-web-deps:
       - file: /srv/pypy
 
 pypy-web-clone:
-  hg.latest:
-    - name: https://foss.heptapod.net/pypy/pypy.org
-    - rev: default
+  git.latest:
+    - name: https://github.com/pypy/pypy.org
+    - rev: gh-pages
     - target: /srv/pypy/pypy.org
     - user: nginx
     - clean: True


### PR DESCRIPTION
Please check carefully, this is my first PR here.

The rendered website for https://pypy.org is now created on the gh-branch of https://github.com/pypy/pypy.org. This is to enable blogs via nikola and the commenting system via the [utterances](https://utteranc.es/) javascript plugin, which interfaces with github.