### PR TITLE
force checkout the gh-pages branch, which is force-pushed

### DIFF
--- a/salt/pypy-web/init.sls
+++ b/salt/pypy-web/init.sls
@@ -26,8 +26,11 @@ pypy-web-clone:
   git.latest:
     - name: https://github.com/pypy/pypy.org
     - rev: gh-pages
+    - branch: gh-pages
     - target: /srv/pypy/pypy.org
     - user: nginx
+    - force_checkout: True
+    - force_fetch: True
     - require:
       - pkg: pypy-web-deps
 


### PR DESCRIPTION
In order to reduce git churn, we force push the gh-pages branch. So the local checkout must use `force_checkout` and `force_fetch`.