### PR TITLE
Setup nginx to compress responses from roundup trackers.

### DIFF
--- a/salt/bugs/config/nginx.conf.jinja
+++ b/salt/bugs/config/nginx.conf.jinja
@@ -9,20 +9,6 @@ upstream tracker-{{ tracker }} {
 
 include conf.d/tracker-extras/upstreams-{{ tracker }}*.conf;
 
-gzip_http_version 1.1;
-gzip_proxied      any;
-gzip_min_length   500;
-# default comp_level is 1
-gzip_comp_level   6;
-gzip_disable      msie6
-gzip_types        text/plain text/css
-                  text/xml application/xml
-                  text/javascript application/javascript
-                  text/json application/json;
-# upstream proxies need to match Accept-Encoding as
-# part of their cache check
-gzip_vary         on
-
 server {
   listen 80;
   server_name {{ server_name }};
@@ -63,6 +49,17 @@ server {
   root /srv/roundup/trackers/{{ tracker }}/;
 
   include conf.d/tracker-extras/{{ tracker }}*.conf;
+
+  gzip              on;
+  gzip_http_version 1.1;
+  gzip_proxied      any;
+  gzip_min_length   500;
+  gzip_comp_level   6;  # default comp_level is 1
+  gzip_disable      msie6;
+  gzip_types        text/plain text/css
+                    text/xml application/xml
+                    text/javascript application/javascript
+                    text/json application/json;
 
   location /@@file/ {
     rewrite ^/@@file/(.*) /html/$1 break;

--- a/salt/bugs/config/nginx.conf.jinja
+++ b/salt/bugs/config/nginx.conf.jinja
@@ -9,6 +9,20 @@ upstream tracker-{{ tracker }} {
 
 include conf.d/tracker-extras/upstreams-{{ tracker }}*.conf;
 
+gzip_http_version 1.1;
+gzip_proxied      any;
+gzip_min_length   500;
+# default comp_level is 1
+gzip_comp_level   6;
+gzip_disable      msie6
+gzip_types        text/plain text/css
+                  text/xml application/xml
+                  text/javascript application/javascript
+                  text/json application/json;
+# upstream proxies need to match Accept-Encoding as
+# part of their cache check
+gzip_vary         on
+
 server {
   listen 80;
   server_name {{ server_name }};


### PR DESCRIPTION
Data returned from the roundup servers is not compressed. Set up nginx to compress the data on the fly.

I overrode the default compression level from 1 to 6 as that seems to provide the best compression ratio/cpu time
on the roundup assets on my system. But lowering that is the system is too stressed works too.

I am not sure if there is an additional proxy upstream, so I enabled gzip_vary. It may not be needed.

Made sure to include xml as a compressed type as the RSS feed uses it.
