### PR TITLE
d.p.o/3.7/library/macpath.html does in fact exists.

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -45,7 +45,7 @@ server {
     location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/howto/(doanddont|webservers).html$ {
         return 301 https://$host/$1$2/;
     }
-    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/(aepack|aetools|aetypes|al|autogil|bastion|bsddb|carbon|cd|colorpicker|commands|compiler|dbhash|dircache|dl|dummy_thread|easydialogs|fl|fm|fpectl|fpformat|framework|future_builtins|gensuitemodule|gl|hotshot|htmllib|ic|imageop|imgfile|imputil|jpeg|mac|macos|macosa|macostools|macpath|md5|mhlib|mimetools|mimewriter|mimify|miniaeframe|multifile|mutex|new|popen2|posixfile|restricted|rexec|rfc822|sgi|sgmllib|sha|someos|statvfs|sun|sunaudio|user).html$ {
+    location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/(aepack|aetools|aetypes|al|autogil|bastion|bsddb|carbon|cd|colorpicker|commands|compiler|dbhash|dircache|dl|dummy_thread|easydialogs|fl|fm|fpectl|fpformat|framework|future_builtins|gensuitemodule|gl|hotshot|htmllib|ic|imageop|imgfile|imputil|jpeg|mac|macos|macosa|macostools|md5|mhlib|mimetools|mimewriter|mimify|miniaeframe|multifile|mutex|new|popen2|posixfile|restricted|rexec|rfc822|sgi|sgmllib|sha|someos|statvfs|sun|sunaudio|user).html$ {
         return 301 https://$host/$1$2/;
     }
     location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/strings.html$ {


### PR DESCRIPTION
https://docs.python.org/3.7/library/macpath.html redirects, but the file exists:

```
mdk@docs:~$ file /srv/docs.python.org/3.7/library/macpath.html 
/srv/docs.python.org/3.7/library/macpath.html: HTML document, UTF-8 Unicode text, with very long lines
```