### PR TITLE
Remove irker.

### DIFF
--- a/pillar/base/bugs.sls
+++ b/pillar/base/bugs.sls
@@ -33,8 +33,6 @@ bugs:
             spambayes_ham_cutoff: "0.2"
             spambayes_spam_cutoff: "0.85"
             ciavc_server: "http://CIA.vc"
-          irker:
-            channels: "irc://irc.libera.chat/python-dev-notifs"
     jython:
       source: https://github.com/psf/bpo-tracker-jython.git
       server_name: bugs.jython.org

--- a/salt/bugs/init.sls
+++ b/salt/bugs/init.sls
@@ -31,14 +31,9 @@ roundup-deps:
   pkg.installed:
     - pkgs:
       - mercurial
-      - irker
       - postfix
       - python-virtualenv
       - python-pip
-
-irkerd:
-  service.running:
-    - enable: True
 
 roundup-user:
   user.present:

--- a/salt/hg/init.sls
+++ b/salt/hg/init.sls
@@ -127,13 +127,6 @@ genauth-wrapper-setuid-setgid-workaround:
     - require:
       - user: hgaccounts-user
 
-/etc/default/irker:
-  file.managed:
-    - user: root
-    - group: root
-    - mode: 644
-    - contents: 'IRKER_OPTIONS="-n deadparrot%03d -H localhost"'
-
 /usr/share/mercurial/templates/hgpythonorg:
   file.recurse:
     - source: salt://hg/files/hg/templates/hgpythonorg
@@ -142,18 +135,6 @@ genauth-wrapper-setuid-setgid-workaround:
     - file_mode: 644
     - require:
       - pkg: hg-deps
-
-irker:
-  pkg.installed:
-    - pkgs:
-      - irker
-  service.running:
-    - enable: True
-    - require:
-      - pkg: irker
-      - file: /etc/default/irker
-    - watch:
-      - file: /etc/default/irker
 
 apache2:
   pkg.installed:


### PR DESCRIPTION
This PR removes all mentions of irker that I found.
AFAIK it was only used by bpo, so removing it should be safe.

This should be merged after the migration is completed.