### PR TITLE
docs: Display a nice 404 when archives are not built yet.

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -26,6 +26,11 @@ server {
         return 302 $scheme://$host/$1/3/;
     }
 
+    # Pretty 404 for archives telling to wait for them to be built.
+    location ~ \.(pdf|zip|epub|bz2)$ {
+        error_page 404 /404.html;
+    }
+
     # Some doc download pages link to docs.python.org/ftp instead of www.python.org/ftp.
     location /ftp/ {
         return 301 https://www.python.org$request_uri;


### PR DESCRIPTION
I'm working on https://github.com/python/docsbuild-scripts/issues/127

The idea is to avoid mails to docs@ telling the PDFs are 404ing.

We had "a lot" of them back then when we were building the PDF daily and the docs hourly. We have less now than we build the PDF at the same rate as the HTML (the html not pointing to an existing PDF lives for less time, but HTML is still build before PDF so users can still hit the 404).

It would allow to get back at the previous state where we were buildling the PDF less often, which would allow for faster HTML builds, for the joy of HTML readers (and the pain of PDF readers maybe).
