### PR TITLE
correctly handle the number of consul hosts available

### DIFF
--- a/salt/consul/etc/_address_list.jinja
+++ b/salt/consul/etc/_address_list.jinja
@@ -1,0 +1,8 @@
+{% set join_addresses = [] -%}
+{% for server in pillar["consul"]["bootstrap"][pillar["dc"]] -%}
+  {% for name, addresses in salt["mine.get"](server, "psf_internal").items()|sort() -%}
+    {% for address in addresses -%}
+      {% do join_addresses.append(address) -%}
+    {% endfor -%}
+  {% endfor -%}
+{% endfor -%}

--- a/salt/consul/etc/join.json.jinja
+++ b/salt/consul/etc/join.json.jinja
@@ -1,14 +1,7 @@
-{% set join_addresses = [] -%}
-{% for server in pillar["consul"]["bootstrap"][pillar["dc"]] -%}
-  {% for name, addresses in salt["mine.get"](server, "psf_internal").items()|sort() -%}
-    {% for address in addresses -%}
-      {% do join_addresses.append(address) -%}
-    {% endfor -%}
-  {% endfor -%}
-{% endfor -%}
+{% import "consul/etc/_address_list.jinja" as address_list %}
 {
     "retry_join": [
-        {% for address in join_addresses|sort() -%}
+        {% for address in address_list.join_addresses|sort() -%}
         "{{ address }}"{% if not loop.last %},{% endif %}
         {% endfor %}
     ]

--- a/salt/consul/etc/server.json.jinja
+++ b/salt/consul/etc/server.json.jinja
@@ -1,5 +1,6 @@
+{% import "consul/etc/_address_list.jinja" as address_list %}
 {
-    "bootstrap_expect": {{ pillar["consul"]["bootstrap"][pillar["dc"]]|length() }},
+    "bootstrap_expect": {{ address_list.join_addresses|length() }},
     "cert_file": "/etc/ssl/private/consul.psf.io.pem",
     "key_file": "/etc/ssl/private/consul.psf.io.pem",
     "server": true


### PR DESCRIPTION
we need to handle the join list _and_ bootstrap_expect for dev, but it is helpful in bootstrapping clusters in deployments.