### PR TITLE
Local letsencrypt

### DIFF
--- a/pillar/base/tls.sls
+++ b/pillar/base/tls.sls
@@ -50,6 +50,10 @@ tls:
       roles:
         - salt-master
 
+    salt-master.vagrant.psf.io:
+      roles:
+        - salt-master-vagrant
+
     svn.psf.io:
       roles:
         - hg

--- a/pillar/dev/pebble.sls
+++ b/pillar/dev/pebble.sls
@@ -1,0 +1,2 @@
+pebble:
+  enabled: True

--- a/pillar/dev/roles.sls
+++ b/pillar/dev/roles.sls
@@ -78,6 +78,10 @@ roles:
     pattern: "salt-master.vagrant.psf.io"
     purpose: ""
     contact: ""
+  salt-master-vagrant:
+    pattern: "salt-master.vagrant.psf.io"
+    purpose: ""
+    contact: ""
   moin:
     pattern: "moin.vagrant.psf.io"
     purpose: ""

--- a/pillar/dev/top.sls
+++ b/pillar/dev/top.sls
@@ -84,6 +84,7 @@ base:
   'salt-master':
     - match: nodegroup
     - firewall.salt
+    - pebble
 
   'speed-web':
     - match: nodegroup

--- a/salt/_extensions/pillar/ca.py
+++ b/salt/_extensions/pillar/ca.py
@@ -254,6 +254,11 @@ def create_ca_signed_cert(
     cert.add_extensions(
         [
             OpenSSL.crypto.X509Extension(
+                b"subjectAltName",
+                False,
+                ", ".join(["DNS:" + CN]).encode('utf-8'),
+            ),
+            OpenSSL.crypto.X509Extension(
                 b"keyUsage",
                 True,
                 b"digitalSignature, keyEncipherment",

--- a/salt/base/config/known_hosts.jinja
+++ b/salt/base/config/known_hosts.jinja
@@ -1,5 +1,6 @@
 {% for server in salt['minion.list']()['minions']|sort -%}
 {% set keys = salt['ssh.recv_known_host_entries'](server, hash_known_hosts=False) -%}
+{% if keys -%}
 {% for key in keys|sort(attribute='enc') -%}
 {{ key['hostname'] }} {{ key['enc'] }} {{ key['key'] }}
-{% endfor %}{%- endfor %}
+{% endfor %}{% endif %}{%- endfor %}

--- a/salt/tls/config/pebble-config.json
+++ b/salt/tls/config/pebble-config.json
@@ -1,0 +1,16 @@
+{
+  "pebble": {
+    "listenAddress": "0.0.0.0:14000",
+    "managementListenAddress": "0.0.0.0:15000",
+    "certificate": "/etc/ssl/private/salt-master.vagrant.psf.io.pem",
+    "privateKey": "/etc/ssl/private/salt-master.vagrant.psf.io.pem",
+    "httpPort": 80,
+    "tlsPort": 443,
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": false,
+    "retryAfter": {
+        "authz": 3,
+        "order": 5
+    }
+  }
+}

--- a/salt/tls/config/pebble.service
+++ b/salt/tls/config/pebble.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Pebble
+After=network.target
+
+[Service]
+Type=simple
+Environment=PEBBLE_VA_ALWAYS_VALID=1
+ExecStart=/usr/local/bin/pebble -config /etc/pebble-config.json
+KillMode=process
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/tls/lego.sls
+++ b/salt/tls/lego.sls
@@ -17,8 +17,13 @@ lego_extract:
   archive.extracted:
     - name: /usr/local/bin/
     - if_missing: /usr/local/bin/lego
-    - source: https://github.com/xenolf/lego/releases/download/v1.2.1/lego_v1.2.1_linux_amd64.tar.gz
-    - source_hash: sha256=ee8252c442e13cac40a2dcdeead9cc5812c44c393e72b39695d428b9275a0509
+    {% if grains.osarch == 'amd64' %}
+    - source: https://github.com/go-acme/lego/releases/download/v4.8.0/lego_v4.8.0_linux_amd64.tar.gz
+    - source_hash: sha256=e8a0d808721af53f64977d4c4811e596cb273e1b950fadd5bf39b6781d2c311c
+    {% elif grains.osarch == 'arm64' %}
+    - source: https://github.com/go-acme/lego/releases/download/v4.8.0/lego_v4.8.0_linux_arm64.tar.gz
+    - source_hash: sha256=b2f43fdccdd434e00547750f40e4203f1a5fdcd5186764d3c52a05635600a220
+    {% endif %}
     - archive_format: tar
     - tar_options: -J --strip-components=1 lego
     - enforce_toplevel: False

--- a/salt/tls/pebble.sls
+++ b/salt/tls/pebble.sls
@@ -1,0 +1,60 @@
+{% if pillar.get('pebble', default={'enabled': False}).enabled %}
+pebble-build-deps:
+  pkg.installed:
+    - pkgs:
+      - golang
+      - git
+
+pebble-golang-workspace:
+  file.directory:
+    - name: /usr/local/golang/pebble
+    - makedirs: True
+
+pebble-source:
+   git.latest:
+     - name: https://github.com/letsencrypt/pebble.git
+     - target: /usr/local/src/pebble
+     - require:
+       - pkg: pebble-build-deps
+
+pebble-build:
+  cmd.run:
+    - creates: /usr/local/golang/pebble/bin/pebble
+    - name: go install ./cmd/pebble
+    - cwd: /usr/local/src/pebble
+    - env:
+      - GOPATH: /usr/local/golang/pebble
+    - requires:
+      - git: pebble-source
+      - file: pebble-golang-workspace
+
+pebble-install:
+  file.copy:
+    - name: /usr/local/bin/pebble
+    - source: /usr/local/golang/pebble/bin/pebble
+    - mode: 755
+
+pebble-config:
+  file.managed:
+    - name: /etc/pebble-config.json
+    - source: salt://tls/config/pebble-config.json
+
+pebble-service:
+  file.managed:
+    - name: /lib/systemd/system/pebble.service
+    - source: salt://tls/config/pebble.service
+    - mode: 644
+
+  service.running:
+    - name: pebble
+    - enable: True
+    - restart: True
+    - require:
+      - file: pebble-install
+      - file: /etc/pebble-config.json
+      - file: /etc/ssl/private/salt-master.vagrant.psf.io.pem
+    - watch:
+      - file: /etc/pebble-config.json
+      - file: /etc/ssl/certs/PSF_CA.pem
+      - file: /etc/ssl/private/salt-master.vagrant.psf.io.pem
+{% endif %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -107,6 +107,7 @@ base:
     - match: nodegroup
     - postgresql.admin
     - dns
+    - tls.pebble
 
   'slack':
     - match: nodegroup


### PR DESCRIPTION
This configures [acme/pebble](https://github.com/letsencrypt/pebble) to run on the salt-master in vagrant to facilitate testing states that involve LetsEncrypt.