### PR TITLE
Upgrade bugs state for Ubuntu 20.04

### DIFF
--- a/salt/bugs/cpython.sls
+++ b/salt/bugs/cpython.sls
@@ -84,6 +84,8 @@ tracker-cpython-nginx-extras-upstreams:
     - source: salt://bugs/config/cpython/tracker-upstreams.conf
     - user: root
     - group: root
+    - require:
+      - file: tracker-nginx-extras
 
 tracker-cpython-nginx-extras:
   file.managed:
@@ -91,3 +93,5 @@ tracker-cpython-nginx-extras:
     - source: salt://bugs/config/cpython/tracker-extras.conf
     - user: root
     - group: root
+    - require:
+      - file: tracker-nginx-extras

--- a/salt/bugs/cpython.sls
+++ b/salt/bugs/cpython.sls
@@ -63,11 +63,11 @@ rietveld:
       - cmd: /etc/systemd/system/rietveld.service
     - watch_any:
       - file: /etc/systemd/system/rietveld.service
-      - hg: rietveld-clone
-      - hg: django-gae2django-clone
+      - git: rietveld-clone
+      - git: django-gae2django-clone
       - file: tracker-cpython-config
       - file: tracker-cpython-detector-config
-      - hg: tracker-cpython-clone
+      - git: tracker-cpython-clone
 
 bpo-suggest:
   service.running:
@@ -76,7 +76,7 @@ bpo-suggest:
       - cmd: /etc/systemd/system/bpo-suggest.service
     - watch_any:
       - file: /etc/systemd/system/bpo-suggest.service
-      - hg: tracker-cpython-clone
+      - git: tracker-cpython-clone
 
 tracker-cpython-nginx-extras-upstreams:
   file.managed:

--- a/salt/bugs/init.sls
+++ b/salt/bugs/init.sls
@@ -33,8 +33,28 @@ roundup-deps:
     - pkgs:
       - mercurial
       - postfix
-      - python-virtualenv
-      - python-pip
+      - python2.7
+      - python2.7-dev
+      - curl
+      - libssl-dev
+      - libpq-dev
+
+roundup-pip:
+  cmd.run:
+    - name: curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
+    - creates: /usr/local/bin/pip2.7
+    - umask: 022
+    - requires:
+      - pkg: roundup-deps
+
+roundup-virtualenv:
+  cmd.run:
+    - name: /usr/local/bin/pip2.7 install "virtualenv<21"
+    - creates: /usr/local/bin/virtualenv
+    - umask: 022
+    - require:
+      - cmd: roundup-pip
+
 
 roundup-user:
   user.present:
@@ -106,8 +126,11 @@ roundup-venv:
   virtualenv.managed:
     - name: /srv/roundup/env/
     - user: roundup
+    - virtualenv_bin: /usr/local/bin/virtualenv
     - python: /usr/bin/python2.7
     - requirements: salt:///bugs/requirements.txt
+    - require:
+      - cmd: roundup-virtualenv
 
 roundup-install:
   pip.installed:

--- a/salt/bugs/init.sls
+++ b/salt/bugs/init.sls
@@ -124,6 +124,8 @@ tracker-nginx-extras:
     - user: root
     - group: root
     - mode: 755
+    - require:
+      - pkg: nginx
 
 {% for tracker, config in pillar["bugs"]["trackers"].items() %}
 tracker-{{ tracker }}-database:
@@ -227,6 +229,8 @@ tracker-{{ tracker }}-nginx-config:
     - context:
       tracker: {{ tracker }}
       server_name: {{ config.get('server_name') }}
+    - require:
+      - file: /etc/nginx/sites.d/
 
 roundup-{{ tracker }}-backup:
   file.directory:
@@ -234,6 +238,7 @@ roundup-{{ tracker }}-backup:
     - user: roundup
     - group: root
     - mode: 750
+    - makedirs: True
 
 tracker-{{ tracker }}-backup:
   cron.present:

--- a/salt/bugs/init.sls
+++ b/salt/bugs/init.sls
@@ -55,6 +55,13 @@ roundup-virtualenv:
     - require:
       - cmd: roundup-pip
 
+roundup-group:
+  group.present:
+    - name: roundup
+    - addusers:
+      - nginx
+    - require:
+      - pkg: nginx
 
 roundup-user:
   user.present:
@@ -63,12 +70,8 @@ roundup-user:
       - roundup
     - home: /srv/roundup
     - createhome: True
-
-roundup-nginx-group-member:
-  group.present:
-    - name: roundup
-    - addusers:
-      - nginx
+    - require:
+      - group: roundup
 
 roundup-home:
   file.directory:

--- a/salt/bugs/postgresql.sls
+++ b/salt/bugs/postgresql.sls
@@ -26,6 +26,7 @@ roundup_postgres_backup_dir:
     - user: postgres
     - group: postgres
     - mode: 750
+    - makedirs: True
 
 roundup_postgres_wal_archives:
   file.directory:

--- a/salt/bugs/roundup.sls
+++ b/salt/bugs/roundup.sls
@@ -4,3 +4,5 @@ tracker-roundup-nginx-extras-upstreams:
     - source: salt://bugs/config/roundup/tracker-upstreams.conf
     - user: root
     - group: root
+    - require:
+      - file: tracker-nginx-extras


### PR DESCRIPTION
- Update state so locally it works with the local lets encrypt service from #258
- Install/configure Python2.7 explicitly, as that is what roundup supports
- Resolve various dependency/requirement issues that stop this state from working from scratch.