### PR TITLE
Upgrade codespeed configuration to run in development

### DIFF
--- a/pillar/dev/secrets/codespeed.sls
+++ b/pillar/dev/secrets/codespeed.sls
@@ -1,0 +1,5 @@
+codespeed-secrets:
+  cpython:
+    secret_key: deadbeef
+  pypy:
+    secret_key: deadbeef

--- a/pillar/dev/secrets/postgresql-users/codespeed.sls
+++ b/pillar/dev/secrets/postgresql-users/codespeed.sls
@@ -1,0 +1,9 @@
+postgresql-users:
+  codespeed-cpython:
+    cluster: pg-vagrant-psf-io
+    dbname: codespeed-cpython
+    password: insecurepasswordlol
+  codespeed-pypy:
+    cluster: pg-vagrant-psf-io
+    dbname: codespeed-pypy
+    password: insecurepasswordlol

--- a/pillar/dev/top.sls
+++ b/pillar/dev/top.sls
@@ -22,6 +22,13 @@ base:
     - fastly-logging
     - firewall.fastly-logging
 
+  'codespeed':
+    - match: nodegroup
+    - firewall.codespeed
+    - codespeed
+    - secrets.postgresql-users.codespeed
+    - secrets.codespeed
+
   'docs':
     - match: nodegroup
     - firewall.rs-lb-backend

--- a/salt/codespeed/init.sls
+++ b/salt/codespeed/init.sls
@@ -9,9 +9,7 @@ codespeed-deps:
     - pkgs:
       - git
       - mercurial
-      - python-dev
       - python3-dev
-      - python-virtualenv
       - python3-virtualenv
       - build-essential
       - libpq-dev


### PR DESCRIPTION
The current status of this PR is that all states are applying aside from:

``` codespeed:           ID: codespeed-cpython-pre-reload
    codespeed:     Function: cmd.run
    codespeed:         Name: /srv/codespeed/cpython/env/bin/python manage.py migrate --noinput && /srv/codespeed/cpython/env/bin/python manage.py collectstatic --noinput
    codespeed:       Result: False
    codespeed:      Comment: Command "/srv/codespeed/cpython/env/bin/python manage.py migrate --noinput && /srv/codespeed/cpython/env/bin/python manage.py collectstatic --noinput" run
    codespeed:      Started: 15:27:47.171804
    codespeed:     Duration: 260.412 ms
    codespeed:      Changes:
    codespeed:               ----------
    codespeed:               pid:
    codespeed:                   1398788
    codespeed:               retcode:
    codespeed:                   1
    codespeed:               stderr:
    codespeed:                   Traceback (most recent call last):
    codespeed:                     File "manage.py", line 9, in <module>
    codespeed:                       execute_from_command_line(sys.argv)
    codespeed:                     File "/srv/codespeed/cpython/env/lib/python3.8/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    codespeed:                       utility.execute()
    codespeed:                     File "/srv/codespeed/cpython/env/lib/python3.8/site-packages/django/core/management/__init__.py", line 328, in execute
    codespeed:                       django.setup()
    codespeed:                     File "/srv/codespeed/cpython/env/lib/python3.8/site-packages/django/__init__.py", line 18, in setup
    codespeed:                       apps.populate(settings.INSTALLED_APPS)
    codespeed:                     File "/srv/codespeed/cpython/env/lib/python3.8/site-packages/django/apps/registry.py", line 108, in populate
    codespeed:                       app_config.import_models(all_models)
    codespeed:                     File "/srv/codespeed/cpython/env/lib/python3.8/site-packages/django/apps/config.py", line 198, in import_models
    codespeed:                       self.models_module = import_module(models_module_name)
    codespeed:                     File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    codespeed:                       return _bootstrap._gcd_import(name[level:], package, level)
    codespeed:                     File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
    codespeed:                     File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    codespeed:                     File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    codespeed:                     File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
    codespeed:                     File "<frozen importlib._bootstrap_external>", line 848, in exec_module
    codespeed:                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
    codespeed:                     File "/srv/codespeed/cpython/src/codespeed/models.py", line 17, in <module>
    codespeed:                       class Project(models.Model):
    codespeed:                   RuntimeError: __class__ not set defining 'Project' as <class 'codespeed.models.Project'>. Was __classcell__ propagated to type.__new__?
```