### PR TITLE
Get docs ready 2 migrate 

### DIFF
--- a/pillar/base/haproxy.sls
+++ b/pillar/base/haproxy.sls
@@ -14,6 +14,7 @@ haproxy:
       domains:
         - docs.python.org
         - doc.python.org
+      check: "HEAD /_check HTTP/1.1\\r\\nHost:\\ docs.python.org"
 
     downloads:
       domains:

--- a/pillar/prod/roles.sls
+++ b/pillar/prod/roles.sls
@@ -31,7 +31,7 @@ roles:
     purpose:  "Runs `Consul <https://www.consul.io/>`_ discovery service"
     contact:  "Infrastructure Staff"
   docs:
-    pattern:  "docs.nyc1.psf.io"
+    pattern:  "docs*.nyc1.psf.io"
     purpose:  "Builds and serves CPython's documentation"
     contact:  "mdk"
   downloads:


### PR DESCRIPTION
Configure health check and modify pillar/prod/roles.sls compatibility for migration of docs to ubuntu 20.0.4