### PR TITLE
backups: move all but private-key to public pillar data

### DIFF
--- a/pillar/prod/backup/bugs.sls
+++ b/pillar/prod/backup/bugs.sls
@@ -1,0 +1,9 @@
+backup:
+  directories:
+    python-bugs-data:
+      source_directory: /backup/
+      target_host: backup.sfo1.psf.io
+      target_directory: /backup/python-bugs
+      target_user: python-bugs
+      frequency: hourly
+      user: root

--- a/pillar/prod/backup/buildbot.sls
+++ b/pillar/prod/backup/buildbot.sls
@@ -1,0 +1,9 @@
+#backup:
+#  directories:
+#    python-buildbot-config:
+#      source_directory: /etc/buildbot/
+#      target_host: backup.sfo1.psf.io
+#      target_directory: /backup/buildbot
+#      target_user: buildbot
+#      frequency: hourly
+#      user: root

--- a/pillar/prod/backup/docs.sls
+++ b/pillar/prod/backup/docs.sls
@@ -1,0 +1,11 @@
+backup:
+  directories:
+    python-docs:
+      source_directory: /srv/
+      exclude:
+        - /srv/docsbuild
+      target_host: backup.sfo1.psf.io
+      target_directory: /backup/python-docs
+      target_user: python-docs
+      frequency: daily
+      user: root

--- a/pillar/prod/backup/downloads.sls
+++ b/pillar/prod/backup/downloads.sls
@@ -1,0 +1,9 @@
+backup:
+  directories:
+    python-downloads:
+      source_directory: /srv/
+      target_host: backup.sfo1.psf.io
+      target_directory: /backup/python-downloads
+      target_user: downloads
+      frequency: daily
+      user: root

--- a/pillar/prod/backup/hg.sls
+++ b/pillar/prod/backup/hg.sls
@@ -1,0 +1,9 @@
+backup:
+  directories:
+    python-hg:
+      source_directory: /srv/
+      target_host: backup.sfo1.psf.io
+      target_directory: /backup/python-hg
+      target_user: hg
+      frequency: daily
+      user: root

--- a/pillar/prod/backup/mail.sls
+++ b/pillar/prod/backup/mail.sls
@@ -1,0 +1,18 @@
+backup:
+  directories:
+    mail-python-org:
+      source_directory: /
+      exclude:
+        - /boot
+        - /dev
+        - /media
+        - /mnt
+        - /proc
+        - /sys
+        - /tmp
+        - /var/spool/postfix
+      target_host: backup.sfo1.psf.io
+      target_directory: /backup/mail-python-org
+      target_user: mail-python-org
+      frequency: daily
+      user: root

--- a/pillar/prod/backup/moin.sls
+++ b/pillar/prod/backup/moin.sls
@@ -1,0 +1,9 @@
+backup:
+  directories:
+    moin:
+      source_directory: /data/
+      target_host: backup.sfo1.psf.io
+      target_directory: /backup/moin
+      target_user: moin
+      frequency: daily
+      user: root

--- a/pillar/prod/backup/server.sls
+++ b/pillar/prod/backup/server.sls
@@ -27,11 +27,6 @@ backup-server:
       user: hg
       increment_retention: 90D
       authorized_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDS0sTCNKlCfJd/TyiKW3HRwTUouo3+PvPOK3ddyfpY17bJ4KdpaMZgc7fNg5VKzFvvuHBqjvVJsdewP3LesLOuaQCQoSu1DniLoodZGRdJ9gqgtbRZf4ekzsn7E7WZUnVI0fbofvFWjbPt3PSxVtm8hCqwmwia53Ehh9G3xRurDhNUqIjrGcTStM3kloQHjKing+EGdCqPvikuwN1eMZXyNnt4zuoU4e39JGCBqRBfXumvrYvYzuNbAN8OZtNAfByzLFJ6DIWq0ihK6WS/KRYKGKivaaK26whafutfv44bP0w3LvZZyTMGGqiS/zLNPx0tkYK3JEt4bpLlyHZHbIBh
-    dinsdale:
-      directory: /backup/dinsdale
-      user: dinsdale
-      increment_retention: 90D
-      authorized_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCy9W2fUjT5GkgB0lFgqLKM0cfs0tvL11Z8/YhaNgyLbY4oHKr6LHS2rePfqkN+JhpslokcnrW5JBWZeiPqYWpTZabQJBL2ylSBKeU7UpoSpiJOm8tM1f30w4BPX7b+XSoiLKcBJTtOVu99fjW3/j8N1jpwcmb3UuHv2h+MKBwjQOZqArkHdXhzyJjmududEZAgdpBUEDN4a1jHrcZhwsci9zLIqTH0SsVKIQe99E2WcXUpdH9UoeJMXpmLBsSnoWbMnKnVruA8fjgOwKMaHEse19rgQ+2SRHmZu1zCltuyWETSSpu4Gfgo4tyxzr9oZLy1ykT0ACTeXyUN/oSZ55nF
     buildbot:
       directory: /backup/buildbot
       user: buildbot

--- a/pillar/prod/top.sls
+++ b/pillar/prod/top.sls
@@ -20,6 +20,7 @@ base:
     - firewall.bugs
     - mail-opt-out
     - secrets.bugs
+    - backup.bugs
     - secrets.backup.bugs
     - bugs
 
@@ -27,6 +28,7 @@ base:
     - match: nodegroup
     - firewall.buildbot
     - secrets.postgresql-users.buildbot
+    - backup.buildbot
     - secrets.backup.buildbot
 
   'cdn-logs':
@@ -46,18 +48,21 @@ base:
     - firewall.rs-lb-backend
     - groups.docs
     - secrets.docs
+    - backup.docs
     - secrets.backup.docs
 
   'downloads':
     - match: nodegroup
     - firewall.rs-lb-backend
     - groups.downloads
+    - backup.downloads
     - secrets.backup.downloads
 
   'hg':
     - match: nodegroup
     - firewall.rs-lb-backend
     - firewall.hg
+    - backup.hg
     - secrets.backup.hg
     - secrets.ssh.hg
 
@@ -72,6 +77,7 @@ base:
   'mail':
     - match: nodegroup
     - firewall.mail
+    - backup.mail
     - secrets.backup.mail
     - groups.mail
     - mail-opt-out
@@ -80,6 +86,7 @@ base:
     - match: nodegroup
     - mail-opt-out
     - firewall.rs-lb-backend
+    - backup.moin
     - secrets.backup.moin
 
   'planet':

--- a/salt/backup/client/init.sls
+++ b/salt/backup/client/init.sls
@@ -19,7 +19,7 @@ include:
 {{ backup }}-ssh-key:
   file.managed:
     - name: /etc/backup/.ssh/id_rsa_{{ backup }}
-    - contents_pillar: backup:directories:{{ backup }}:ssh_key
+    - contents_pillar: backup-secret:directories:{{ backup }}:ssh_key
     - user: {{ config['user'] }}
     - mode: 600
     - show_diff: False

--- a/salt/backup/client/init.sls
+++ b/salt/backup/client/init.sls
@@ -6,13 +6,13 @@ include:
   file.directory:
     - user: root
     - group: root
-    - mode: 755
+    - mode: "0755"
 
 /etc/backup/.ssh:
   file.directory:
     - user: root
     - group: root
-    - mode: 755
+    - mode: "0755"
 
 {% for backup, config in salt['pillar.get']('backup:directories', {}).items() %}
 
@@ -21,7 +21,7 @@ include:
     - name: /etc/backup/.ssh/id_rsa_{{ backup }}
     - contents_pillar: backup-secret:directories:{{ backup }}:ssh_key
     - user: {{ config['user'] }}
-    - mode: 600
+    - mode: "0600"
     - show_diff: False
 
 {{ backup }}-script-dir:
@@ -33,7 +33,7 @@ include:
   file.managed:
     - name: /usr/local/backup/{{ backup }}/scripts/backup.bash
     - user: {{ config['user'] }}
-    - mode: 500
+    - mode: "0500"
     - source: salt://backup/client/templates/backup.bash.jinja
     - template: jinja
     - context:


### PR DESCRIPTION
this ensures that backup config is viewable by all users, and can be updated by anyone.