### PR TITLE
prepare downloads role for migration

### DIFF
--- a/pillar/prod/roles.sls
+++ b/pillar/prod/roles.sls
@@ -35,7 +35,7 @@ roles:
     purpose:  "Builds and serves CPython's documentation"
     contact:  "mdk"
   downloads:
-    pattern:  "downloads.nyc1.psf.io"
+    pattern:  "downloads*.nyc1.psf.io"
     purpose:  "Serves python.org downloads"
     contact:  "CPython Release Managers"
   hg:

--- a/salt/downloads/init.sls
+++ b/salt/downloads/init.sls
@@ -13,15 +13,6 @@ include:
       - file: /etc/nginx/fastly_params
 
 
-/srv/www.python.org/_check:
-  file.managed:
-    - user: root
-    - group: downloads
-    - mode: "0644"
-    - makedirs: True
-    - dir_mode: "0775"
-
-
 /etc/consul.d/service-downloads.json:
   file.managed:
     - source: salt://consul/etc/service.jinja


### PR DESCRIPTION
1) update pattern for downloads role
2) don't create _check file for HTTP health check, so that new host will not join loadbalancer