### PR TITLE
Make `.html` optional for toplevel page redirects

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -177,7 +177,7 @@ server {
     location ~ ^/((archives|c-api|distutils|extending|faq|howto|install|library|reference|tutorial|using|whatsnew|_images|_sources|_static)(/.*)?)$ {
         return 301 https://$host/3/$1;
     }
-    location ~ ^/(about|bugs|contents|copyright|download|genindex.*|glossary|index|license|py-modindex|search).html$ {
+    location ~ ^/(about|bugs|contents|copyright|download|genindex.*|glossary|index|license|py-modindex|search)(.html)?$ {
         return 301 https://$host/3/$1.html;
     }
     location ~ ^/(searchindex.js|objects.inv)$ {


### PR DESCRIPTION
This allows for, e.g., `https://docs.python.org/about` -> `https://docs.python.org/3/about.html`