### PR TITLE
add all Fastly IPs for cdn-logs host

### DIFF
--- a/pillar/base/firewall/fastly-logging.sls
+++ b/pillar/base/firewall/fastly-logging.sls
@@ -1,8 +1,66 @@
 firewall:
-  # See for http://docs.fastly.com/guides/22951283/21713181 IP blocks.
-  fastly_syslog_tcp_72:
-    source: 199.27.72.0/24
+  # See https://developer.fastly.com/reference/api/utils/public-ip-list/
+  fastly_syslog_ipv4_a:
+    source: 23.235.32.0/20
     port: 514
-  fastly_syslog_tcp_77:
-    source: 199.27.77.0/24
+  fastly_syslog_ipv4_b:
+    source: 43.249.72.0/22
+    port: 514
+  fastly_syslog_ipv4_c:
+    source: 103.244.50.0/24
+    port: 514
+  fastly_syslog_ipv4_d:
+    source: 103.245.222.0/23
+    port: 514
+  fastly_syslog_ipv4_e:
+    source: 103.245.224.0/24
+    port: 514
+  fastly_syslog_ipv4_f:
+    source: 104.156.80.0/20
+    port: 514
+  fastly_syslog_ipv4_g:
+    source: 140.248.64.0/18
+    port: 514
+  fastly_syslog_ipv4_h:
+    source: 140.248.128.0/17
+    port: 514
+  fastly_syslog_ipv4_i:
+    source: 146.75.0.0/17
+    port: 514
+  fastly_syslog_ipv4_j:
+    source: 151.101.0.0/16
+    port: 514
+  fastly_syslog_ipv4_k:
+    source: 157.52.64.0/18
+    port: 514
+  fastly_syslog_ipv4_l:
+    source: 167.82.0.0/17
+    port: 514
+  fastly_syslog_ipv4_m:
+    source: 167.82.128.0/20
+    port: 514
+  fastly_syslog_ipv4_n:
+    source: 167.82.160.0/20
+    port: 514
+  fastly_syslog_ipv4_o:
+    source: 167.82.224.0/20
+    port: 514
+  fastly_syslog_ipv4_p:
+    source: 172.111.64.0/18
+    port: 514
+  fastly_syslog_ipv4_q:
+    source: 185.31.16.0/22
+    port: 514
+  fastly_syslog_ipv4_s:
+    source: 199.27.72.0/21
+    port: 514
+  fastly_syslog_ipv4_t:
+    source: 199.232.0.0/16
+    port: 514
+
+  fastly_syslog_ipv6_a:
+    source6: 2a04:4e40::/32
+    port: 514
+  fastly_syslog_ipv6_b:
+    source6: 2a04:4e42::/32
     port: 514


### PR DESCRIPTION
the IPs for syslog sources changed in May... this restores log streaming