### PR TITLE
pebble-source state failing

### DIFF
--- a/salt/tls/pebble.sls
+++ b/salt/tls/pebble.sls
@@ -13,6 +13,7 @@ pebble-golang-workspace:
 pebble-source:
    git.latest:
      - name: https://github.com/letsencrypt/pebble.git
+     - force_reset: remote-changes
      - target: /usr/local/src/pebble
      - require:
        - pkg: pebble-build-deps


### PR DESCRIPTION
When bringing up the salt-master locally, the pebble-source state `git.latest` function fails with this comment: `Repository would be updated from 087582e to d5fa738, but there are uncommitted changes. Set 'force_reset' to True (or 'remote-changes') to force this update and discard these changes.`

By defualt, `git.lastest` `force_reset` is set to false. By changing our configuration to use `force_reset: remote-changes`, we can instruct[ salt](https://docs.saltproject.io/en/latest/ref/states/all/salt.states.git.html#:~:text=in%20version%202015.8.0.-,force_resetFalse,-If%20the%20update) not to discard local changes if the repo is up-to-date with the remote repository.