### PR TITLE
Add a default option 

### DIFF
--- a/pillar/base/users.sls
+++ b/pillar/base/users.sls
@@ -248,6 +248,8 @@ users:
       mail:
         allowed: True
         sudo: True
+        groups:
+          - mailman
 
   hildeb:
     fullname: "Ralf Hildebrandt"
@@ -290,6 +292,8 @@ users:
       mail:
         allowed: True
         sudo: True
+        groups:
+          - mailman
 
   ambv:
     fullname: "Łukasz Langa"

--- a/pillar/base/users.sls
+++ b/pillar/base/users.sls
@@ -80,9 +80,6 @@ users:
         allowed: True
         groups:
           - downloads
-      mailman:
-        allowed: True
-        sudo: True
       mail:
         allowed: True
         sudo: True
@@ -251,8 +248,6 @@ users:
       mail:
         allowed: True
         sudo: True
-        groups:
-          - mailman
 
   hildeb:
     fullname: "Ralf Hildebrandt"
@@ -295,8 +290,6 @@ users:
       mail:
         allowed: True
         sudo: True
-        groups:
-          - mailman
 
   ambv:
     fullname: "Łukasz Langa"

--- a/salt/users/init.sls
+++ b/salt/users/init.sls
@@ -4,7 +4,7 @@ include:
 {% for user_name, user_config in salt["pillar.get"]("users", {}).items() %}
 {% set admin = user_config.get("admin", false) %}
 {% set access = {} %}
-{% for pat, data in user_config.get("access", {}).items() if salt["match.compound"](salt["pillar.get"]("roles:" + pat + ":pattern")) %}  # " Syntax fix
+{% for pat, data in user_config.get("access", {}).items() if salt["match.compound"](salt["pillar.get"]("roles:" + pat + ":pattern", "devnull.psf.io")) %}  # " Syntax fix
   {% do access.update(data) %}
 {% endfor %}
 
@@ -22,7 +22,7 @@ include:
 {% for user_name, user_config in salt["pillar.get"]("users", {}).items() %}
 {% set admin = user_config.get("admin", false) %}
 {% set access = {} %}
-{% for pat, data in user_config.get("access", {}).items() if salt["match.compound"](salt["pillar.get"]("roles:" + pat + ":pattern")) %}  # " Syntax fix
+{% for pat, data in user_config.get("access", {}).items() if salt["match.compound"](salt["pillar.get"]("roles:" + pat + ":pattern", "devnull.psf.io")) %}  # " Syntax fix
   {% do access.update(data) %}
 {% endfor %}
 


### PR DESCRIPTION
Adding a default option to prevent returning an empty string to `match.compound` removing error addressed in #297

Note: this locks up `devnull.psf.io` from being used in the future. 