### PR TITLE
Removing trailing slash on `pkgrepo.managed` URLs 

### DIFF
--- a/salt/base/repo.sls
+++ b/salt/base/repo.sls
@@ -7,7 +7,7 @@
 
 psf:
   pkgrepo.managed:
-    - name: "deb https://packagecloud.io/psf/infra/ubuntu/ {{ grains['oscodename'] }} main"
+    - name: "deb https://packagecloud.io/psf/infra/ubuntu {{ grains['oscodename'] }} main"
     - file: /etc/apt/sources.list.d/psf.list
     - key_url: salt://base/config/APT-GPG-KEY-PSF
 

--- a/salt/bugs/postgresql.sls
+++ b/salt/bugs/postgresql.sls
@@ -2,7 +2,7 @@
 pgdg-repo:
   pkgrepo.managed:
     - humanname: PostgresSQL Global Development Group
-    - name: deb http://apt.postgresql.org/pub/repos/apt/ {{ grains['oscodename'] }}-pgdg main
+    - name: deb http://apt.postgresql.org/pub/repos/apt {{ grains['oscodename'] }}-pgdg main
     - file: /etc/apt/sources.list.d/pgdg.list
     - gpgcheck: 1
     - key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc

--- a/salt/datadog/init.sls
+++ b/salt/datadog/init.sls
@@ -1,6 +1,6 @@
 datadog_repo:
   pkgrepo.managed:
-    - name: "deb https://apt.datadoghq.com/ stable 6"
+    - name: "deb https://apt.datadoghq.com stable 6"
     - file: /etc/apt/sources.list.d/datadog.list
     - key_url: salt://datadog/config/APT-GPG-KEY-DATADOG
 

--- a/salt/nginx/init.sls
+++ b/salt/nginx/init.sls
@@ -1,6 +1,6 @@
 nginx:
   pkgrepo.managed:
-    - name: deb http://nginx.org/packages/ubuntu/ {{ grains.oscodename }} nginx
+    - name: deb http://nginx.org/packages/ubuntu {{ grains.oscodename }} nginx
     - file: /etc/apt/sources.list.d/nginx.list
     - key_url: salt://nginx/config/APT-GPG-KEY-NGINX
     - order: 2

--- a/salt/postgresql/base/init.sls
+++ b/salt/postgresql/base/init.sls
@@ -1,6 +1,6 @@
 postgresql-repo:
   pkgrepo.managed:
-    - name: "deb http://apt.postgresql.org/pub/repos/apt/ {{ grains['oscodename'] }}-pgdg main"
+    - name: "deb http://apt.postgresql.org/pub/repos/apt {{ grains['oscodename'] }}-pgdg main"
     - file: /etc/apt/sources.list.d/postgresql.list
     - key_url: salt://postgresql/base/APT-GPG-KEY-POSTGRESQL
     - order: 2


### PR DESCRIPTION
Removing trailing slash on `pkgrepo.managed` URLs to prevent states from always reporting changed. This addresses issue #299 with reference to https://github.com/saltstack/salt/issues/58781