### PR TITLE
Configure salt to manage psf_known_hosts and salt-server-list.rst

### DIFF
--- a/pillar/base/haproxy.sls
+++ b/pillar/base/haproxy.sls
@@ -94,6 +94,11 @@ haproxy:
       verify_host: salt.psf.io
       check: "GET /.well-known/acme-challenge/sentinel HTTP/1.1\\r\\nHost:\\ salt.psf.io"
 
+    publish-files:
+      domains: []
+      verify_host: salt-public.psf.io
+      check: "GET /srv/public HTTP/1.1\\r\\nHost:\\ salt-public.psf.io"
+
   redirects:
     cheeseshop.python.org:
       target: pypi.org

--- a/pillar/base/haproxy.sls
+++ b/pillar/base/haproxy.sls
@@ -95,9 +95,10 @@ haproxy:
       check: "GET /.well-known/acme-challenge/sentinel HTTP/1.1\\r\\nHost:\\ salt.psf.io"
 
     publish-files:
-      domains: []
-      verify_host: salt-public.psf.io
-      check: "GET /srv/public HTTP/1.1\\r\\nHost:\\ salt-public.psf.io"
+      domains:
+        - salt-public.psf.io
+      verify_host: salt.psf.io
+      check: "GET /salt-server-list.rst HTTP/1.1\\r\\nHost:\\ salt-public.psf.io"
 
   redirects:
     cheeseshop.python.org:

--- a/salt/base/config/publish-files-nginx.conf
+++ b/salt/base/config/publish-files-nginx.conf
@@ -1,0 +1,13 @@
+server {
+  listen 80 ssl default_server;
+
+  ssl_certificate /etc/ssl/private/salt.psf.io.pem;
+  ssl_certificate_key /etc/ssl/private/salt.psf.io.pem;
+
+  server_name _;
+
+  location / {
+      root /srv/public;
+      try_files $uri =404;
+  }
+}

--- a/salt/base/config/publish-files-nginx.conf
+++ b/salt/base/config/publish-files-nginx.conf
@@ -1,10 +1,10 @@
 server {
-  listen 9001 ssl salt-public.psf.io;
+  listen 9001 ssl;
 
   ssl_certificate /etc/ssl/private/salt.psf.io.pem;
   ssl_certificate_key /etc/ssl/private/salt.psf.io.pem;
 
-  salt-public.psf.io _;
+  server_name salt-public.psf.io;
 
   location / {
       root /srv/public;

--- a/salt/base/config/publish-files-nginx.conf
+++ b/salt/base/config/publish-files-nginx.conf
@@ -1,10 +1,10 @@
 server {
-  listen 80 ssl default_server;
+  listen 9001 ssl salt-public.psf.io;
 
   ssl_certificate /etc/ssl/private/salt.psf.io.pem;
   ssl_certificate_key /etc/ssl/private/salt.psf.io.pem;
 
-  server_name _;
+  salt-public.psf.io _;
 
   location / {
       root /srv/public;

--- a/salt/base/salt.sls
+++ b/salt/base/salt.sls
@@ -84,7 +84,7 @@ salt-master:
   file.directory:
     - user: root
     - group: root
-    - mode: "0644"
+    - mode: "0755"
 
 /srv/public/psf_known_hosts:
   file.managed:
@@ -116,7 +116,7 @@ salt-master:
     - template: jinja
     - context:
        name: publish-files
-       port: 9000
+       port: 9001
     - user: root
     - group: root
     - mode: "0644"

--- a/salt/base/salt.sls
+++ b/salt/base/salt.sls
@@ -107,6 +107,7 @@ salt-master:
     - source: salt://base/config/publish-files-nginx.conf
     - user: root
     - group: root
+    - mode: "0644"
     - require:
        - file: /srv/public
 

--- a/salt/base/salt.sls
+++ b/salt/base/salt.sls
@@ -80,7 +80,13 @@ salt-master:
     - require:
       - pkg: consul-pkgs
 
-/srv/psf_known_hosts:
+/srv/public:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: "0644"
+
+/srv/public/psf_known_hosts:
   file.managed:
     - source: salt://base/config/known_hosts.jinja
     - template: jinja
@@ -88,13 +94,36 @@ salt-master:
     - group: root
     - mode: "0644"
 
-/srv/salt-server-list.rst:
+/srv/public/salt-server-list.rst:
   file.managed:
     - source: salt://base/config/salt-server-list.rst.jinja
     - template: jinja
     - user: root
     - group: root
     - mode: "0644"
+
+/etc/nginx/sites.d/publish-files.conf:
+  file.managed:
+    - source: salt://base/config/publish-files-nginx.conf
+    - user: root
+    - group: root
+    - require:
+       - file: /srv/public
+
+/etc/consul.d/service-publish-files.conf:
+  file.managed:
+    - source: salt://consul/etc/service.jinja
+    - template: jinja
+    - context:
+       name: publish-files
+       port: 9000
+    - user: root
+    - group: root
+    - mode: "0644"
+    - require:
+       - pkg: consul-pkgs
+
+
 {% endif %}
 
 salt-minion-pkg:

--- a/salt/base/salt.sls
+++ b/salt/base/salt.sls
@@ -109,6 +109,7 @@ salt-master:
     - group: root
     - mode: "0644"
     - require:
+       - file: /etc/nginx/sites.d/
        - file: /srv/public
 
 /etc/consul.d/service-publish-files.conf:

--- a/salt/base/salt.sls
+++ b/salt/base/salt.sls
@@ -115,8 +115,8 @@ salt-master:
     - source: salt://consul/etc/service.jinja
     - template: jinja
     - context:
-       name: publish-files
-       port: 9001
+        name: publish-files
+        port: 9001
     - user: root
     - group: root
     - mode: "0644"


### PR DESCRIPTION
Configure salt to manage psf_known_hosts and salt-server-list.rst and serve them via HTTP