### PR TITLE
Adding needed font for ja PDF builds.

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -11,6 +11,7 @@ doc-pkgs:
     - pkgs:
       - build-essential
       - fonts-freefont-otf
+      - fonts-noto
       - git
       - mercurial
       - python3.10-dev


### PR DESCRIPTION
see: https://github.com/python/python-docs-ja/issues/31#issuecomment-1465791751

I'm trying it manually before, to ensure that's why we need, nothing more is needed, and it actually fix the proble, so please don't merge now.