### PR TITLE
Fix /ftp redirect on docs.python.org for archives

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -32,7 +32,7 @@ server {
     }
 
     # Some doc download pages link to docs.python.org/ftp instead of www.python.org/ftp.
-    location /ftp/ {
+    location ^~ /ftp/ {
         return 301 https://www.python.org$request_uri;
     }
 


### PR DESCRIPTION
The `^~` modifier makes this rule take priority priority over regex
(specifically the `pdf|zip|epub|bz2` regex above), see
https://nginx.org/en/docs/http/ngx_http_core_module.html#location

See: https://github.com/python/cpython/issues/95290