### PR TITLE
docs: Build more often.

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -78,7 +78,6 @@ docsbuild-full:
     - name: /srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py
     - user: docsbuild
     - minute: 7
-    - hour: 0
     - require:
       - cmd: virtualenv-dependencies
 


### PR DESCRIPTION
The script will just die soon if another insance already runs (it uses a file lock), so there's no fear at starting it too often.

Also the script does no longer build documentation that has not changed (by checking the cpython and translation shas), so runnig the script more often will not introduce more load, just faster builds.

closes #320.