### PR TITLE
Fix local dev

### DIFF
--- a/pillar/base/haproxy.sls
+++ b/pillar/base/haproxy.sls
@@ -47,7 +47,7 @@ haproxy:
     hg:
       domains:
         - hg.python.org
-      check: "GET /test/rev/ea32503c754c HTTP/1.1\\r\\nHost:\\ hg.python.org"
+      check: "GET / HTTP/1.1\\r\\nHost:\\ hg.python.org"
       verify_host: hg.psf.io
 
     jobs:

--- a/salt/hg/init.sls
+++ b/salt/hg/init.sls
@@ -18,6 +18,24 @@ hg-user:
     - require:
       - user: hgaccounts-user
 
+/srv/hg:
+  file.directory:
+    - user: hg
+    - group: hg
+    - mode: "0755"
+
+/srv/hgaccounts:
+  file.directory:
+    - user: hgaccounts
+    - group: hgaccounts
+    - mode: "0755"
+
+/srv/hg/repos:
+  file.directory:
+    - user: hg
+    - group: hg
+    - mode: "0755"
+
 /srv/hg/bin:
   file.recurse:
     - source: salt://hg/files/hg/bin


### PR DESCRIPTION
These changes prepare hg for future X-Forwarded-For, and rate-limiting configurations. 

To test that this is working locally: 

1. bring up the salt-master, `laptop:psf-salt user$ vagrant up salt-master`
2. bring up the loadbalancer, `laptop:psf-salt user$ vagrant up loadbalancer`
3. bring up hg, `laptop:psf-salt user$ vagrant up hg`
4. in another window, ssh into the vagrant hg box, `vagrant shh hg`
5. install curl `sudo apt install curl`
6. to test localhost, `for i in {1..20}; do curl -o /dev/null -s -w "%{http_code}\n" -k -H "Host: hg.python.org" https://127.0.0.1:9000; done`
7. to test loadbalancer, `for i in {1..20}; do curl -o /dev/null -s -w "%{http_code}\n" -k -H "Host: hg.python.org" https://192.168.50.19/; done`