### PR TITLE
mod_remoteip for X-Forwarded-For handling 

### DIFF
--- a/salt/hg/config/remoteip.apache.conf.jinja
+++ b/salt/hg/config/remoteip.apache.conf.jinja
@@ -1,0 +1,22 @@
+# Load the mod_remoteip module
+LoadModule remoteip_module modules/mod_remoteip.so
+
+# Set an environment variable 'forwarded' if the XFF header is present
+SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+
+# Define 'combined' and 'forwarded' log formats
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" forwarded
+
+# Specify location of error log file
+ErrorLog ${APACHE_LOG_DIR}/error.log
+
+# Configure access logs with conditional logging
+CustomLog ${APACHE_LOG_DIR}/access.log combined env=!forwarded
+CustomLog ${APACHE_LOG_DIR}/access.log forwarded env=forwarded
+
+# Configure mod_remoteip to update client IP using XFF header
+# Specify internal proxy ips to be trusted
+RemoteIPHeader X-Forwarded-For
+RemoteIPInternalProxy 127.0.0.1
+RemoteIpInternalProxy  {{ pillar["psf_internal_network"] }}

--- a/salt/hg/init.sls
+++ b/salt/hg/init.sls
@@ -171,6 +171,10 @@ apache2:
       - file: /etc/apache2/mods-enabled/*
       - file: /etc/ssl/private/hg.psf.io.pem
 
+/etc/apache2/mods-enabled/remoteip.load:
+  file.symlink:
+    - target: /etc/apache2/mods-available/remoteip.load
+
 /etc/apache2/mods-enabled/headers.load:
   file.symlink:
     - target: /etc/apache2/mods-available/headers.load

--- a/salt/hg/init.sls
+++ b/salt/hg/init.sls
@@ -264,7 +264,7 @@ apache2:
     - group: root
     - mode: "0644"
 
-/etc/apache2/sites-available/remoteip.conf:
+/etc/apache2/conf-available/remoteip.conf:
   file.managed:
     - source: salt://hg/config/remoteip.apache.conf.jinja
     - template: jinja
@@ -274,9 +274,9 @@ apache2:
     - require:
       - pkg: apache2
 
-/etc/apache2/sites-enabled/remoteip.conf:
+/etc/apache2/conf-enabled/remoteip.conf:
   file.symlink:
-    - target: ../sites-available/remoteip.conf
+    - target: ../conf-available/remoteip.conf
     - user: root
     - group: root
     - mode: "0644"

--- a/salt/hg/init.sls
+++ b/salt/hg/init.sls
@@ -260,6 +260,23 @@ apache2:
     - group: root
     - mode: "0644"
 
+/etc/apache2/sites-available/remoteip.conf:
+  file.managed:
+    - source: salt://hg/config/remoteip.apache.conf.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: "0644"
+    - require:
+      - pkg: apache2
+
+/etc/apache2/sites-enabled/remoteip.conf:
+  file.symlink:
+    - target: ../sites-available/remoteip.conf
+    - user: root
+    - group: root
+    - mode: "0644"
+
 /etc/apache2/REDIRECTS:
   file.directory:
     - user: root

--- a/salt/hg/init.sls
+++ b/salt/hg/init.sls
@@ -169,6 +169,8 @@ apache2:
       - file: /etc/apache2/sites-available/*
       - file: /etc/apache2/sites-enabled/*
       - file: /etc/apache2/mods-enabled/*
+      - file: /etc/apache2/conf-available/*
+      - file: /etc/apache2/conf-enabled/*
       - file: /etc/ssl/private/hg.psf.io.pem
 
 /etc/apache2/mods-enabled/remoteip.load:


### PR DESCRIPTION
This PR introduces a globally applied `mod_remoteip` configuration for handling client IPs, preparing for future rate-limiting configurations. It also specifies a salt state to manage `remoteip.conf`, creates a symlink to define the configuration, and another symlink to enable the configuration.

To verify these changes locally: 
1. bring up the salt-master, `laptop:psf-salt user$ vagrant up salt-master`
2. bring up the loadbalancer, `laptop:psf-salt user$ vagrant up loadbalancer`
3. bring up hg, `laptop:psf-salt user$ vagrant up hg`
4. in another window, ssh into the vagrant hg box, `laptop:psf-salt user$  vagrant ssh hg`
5. in another window, from your local computer, run the curl command `curl -k https://127.0.0.1:20010/hello -H "Host: hg.python.org"`
6. in the vagrant box, run `sudo tail -f /var/log/apache2/hg.access.log | grep hello`

