### PR TITLE
Ratelimit

### DIFF
--- a/pillar/base/ratelimit.sls
+++ b/pillar/base/ratelimit.sls
@@ -1,4 +1,4 @@
 rate_limit_config:
-  requests: 120
-  per_second: 10
+  requests: 1
+  per_second: 1
   resposne_code: 429

--- a/pillar/base/ratelimit.sls
+++ b/pillar/base/ratelimit.sls
@@ -1,0 +1,4 @@
+rate_limit_config:
+  requests: 120
+  per_second: 10
+  resposne_code: 429

--- a/pillar/dev/top.sls
+++ b/pillar/dev/top.sls
@@ -41,6 +41,7 @@ base:
   'hg':
     - match: nodegroup
     - firewall.rs-lb-backend
+    - ratelimit
 
   'loadbalancer':
     - match: nodegroup

--- a/salt/hg/config/hg.apache.conf.jinja
+++ b/salt/hg/config/hg.apache.conf.jinja
@@ -1,5 +1,13 @@
+# Configure rate limiting
+QS_ClientEventLimitCount {{pillar.get("rate_limit_config", {}).get("requests", 10) }} {{pillar.get("rate_limit_config", {}).get("per_second", 60) }} rate_limit
+QS_ClientEventPerSecLimit 1
+QS_ErrorResponseCode {{pillar.get("rate_limit_config", {}).get("response_code", 429)}}
+
 <VirtualHost _default_:9000>
-    ServerName hg.python.org
+    SetEnvIf Request_URI / rate_limit=1
+
+    ServerName hg.psf.io
+    ServerAlias hg.python.org
 
     SSLEngine on
     SSLCertificateFile /etc/ssl/private/hg.psf.io.pem

--- a/salt/hg/config/hg.apache.conf.jinja
+++ b/salt/hg/config/hg.apache.conf.jinja
@@ -1,9 +1,5 @@
-# Configure rate limiting
-QS_ClientEventLimitCount {{pillar.get("rate_limit_config", {}).get("requests", 10) }} {{pillar.get("rate_limit_config", {}).get("per_second", 60) }} rate_limit
-QS_ClientEventPerSecLimit 1
-QS_ErrorResponseCode {{pillar.get("rate_limit_config", {}).get("response_code", 429)}}
-
 <VirtualHost _default_:9000>
+    # The line below applies rate limiting rules, configred in ratelimit.apache.conf.jinja
     SetEnvIf Request_URI / rate_limit=1
 
     ServerName hg.psf.io

--- a/salt/hg/config/ratelimit.apache.conf.jinja
+++ b/salt/hg/config/ratelimit.apache.conf.jinja
@@ -1,1 +1,0 @@
-{{ pillar.get("rate_limit_config") }}

--- a/salt/hg/config/ratelimit.apache.conf.jinja
+++ b/salt/hg/config/ratelimit.apache.conf.jinja
@@ -1,4 +1,16 @@
+#Exclude internal loadbalancer IP range from rate limiting
+#QS_SrvMaxConnExcludeIP {{ pillar["psf_internal_network"] }}
+
 # Configure rate limiting
 QS_ClientEventLimitCount {{pillar.get("rate_limit_config", {}).get("requests", 10) }} {{pillar.get("rate_limit_config", {}).get("per_second", 60) }} rate_limit
 QS_ClientEventPerSecLimit 1
 QS_ErrorResponseCode {{pillar.get("rate_limit_config", {}).get("response_code", 429)}}
+
+<If "%{REMOTE_ADDR} -ipmatch '{{ pillar["psf_internal_network"] }}'">
+ Header set My-Header "inisde"
+</If>
+
+Header set My-Header "{{ pillar["psf_internal_network"] }}"
+
+## Configure VIP Ip Header Name to include our loadbalancer and prevent it from getting rate limited
+QS_VipIpHeaderName My-Header drop

--- a/salt/hg/config/ratelimit.apache.conf.jinja
+++ b/salt/hg/config/ratelimit.apache.conf.jinja
@@ -2,9 +2,3 @@
 QS_ClientEventLimitCount {{pillar.get("rate_limit_config", {}).get("requests", 10) }} {{pillar.get("rate_limit_config", {}).get("per_second", 60) }} rate_limit
 QS_ClientEventPerSecLimit 1
 QS_ErrorResponseCode {{pillar.get("rate_limit_config", {}).get("response_code", 429)}}
-
-# Configure VIP Ip Header Name to include our loadbalancer and prevent it from getting rate limited
-QS_VipIpHeaderName My-Header drop
-<If "%{REMOTE_ADDR} -ipmatch '{{ pillar["psf_internal_network"] }}'">
- Header set My-Header "inside"
-</If>

--- a/salt/hg/config/ratelimit.apache.conf.jinja
+++ b/salt/hg/config/ratelimit.apache.conf.jinja
@@ -1,0 +1,10 @@
+# Configure rate limiting
+QS_ClientEventLimitCount {{pillar.get("rate_limit_config", {}).get("requests", 10) }} {{pillar.get("rate_limit_config", {}).get("per_second", 60) }} rate_limit
+QS_ClientEventPerSecLimit 1
+QS_ErrorResponseCode {{pillar.get("rate_limit_config", {}).get("response_code", 429)}}
+
+# Configure VIP Ip Header Name to include our loadbalancer and prevent it from getting rate limited
+QS_VipIpHeaderName My-Header drop
+<If "%{REMOTE_ADDR} -ipmatch '{{ pillar["psf_internal_network"] }}'">
+ Header set My-Header "inside"
+</If>

--- a/salt/hg/config/ratelimit.apache.conf.jinja
+++ b/salt/hg/config/ratelimit.apache.conf.jinja
@@ -1,0 +1,1 @@
+{{ pillar.get("rate_limit_config") }}

--- a/salt/hg/init.sls
+++ b/salt/hg/init.sls
@@ -159,6 +159,7 @@ apache2:
     - pkgs:
       - apache2
       - libapache2-mod-wsgi
+      - libapache2-mod-qos
   service.running:
     - enable: True
     - reload: True
@@ -225,6 +226,9 @@ apache2:
   file.symlink:
     - target: /etc/apache2/mods-available/rewrite.load
 
+/etc/apache2/mods-enabled/unique_id.load:
+  file.symlink:
+    - target: /etc/apache2/mods-available/unique_id.load
 
 /etc/apache2/ports.conf:
   file.managed:

--- a/salt/hg/init.sls
+++ b/salt/hg/init.sls
@@ -173,6 +173,10 @@ apache2:
       - file: /etc/apache2/conf-enabled/*
       - file: /etc/ssl/private/hg.psf.io.pem
 
+/etc/apache2/mods-enabled/qos.load:
+  file.symlink:
+    - target: /etc/apache2/mods-available/qos.load
+
 /etc/apache2/mods-enabled/remoteip.load:
   file.symlink:
     - target: /etc/apache2/mods-available/remoteip.load

--- a/salt/hg/init.sls
+++ b/salt/hg/init.sls
@@ -283,6 +283,23 @@ apache2:
     - group: root
     - mode: "0644"
 
+/etc/apache2/conf-available/ratelimit.conf:
+  file.managed:
+    - source: salt://hg/config/ratelimit.apache.conf.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: "0644"
+    - require:
+      - pkg: apache2
+
+/etc/apache2/conf-enabled/ratelimit.conf:
+  file.symlink:
+    - target: ../conf-available/ratelimit.conf
+    - user: root
+    - group: root
+    - mode: "0644"
+
 /etc/apache2/REDIRECTS:
   file.directory:
     - user: root


### PR DESCRIPTION
WIP: Currently, this PR introduces globally applied `mod_qos` [Client Level Control ](https://mod-qos.sourceforge.net/#clientlevelcontrol)directives to establish rate limiting for our hg service. Although, the current configuration applies rate limiting specifically to `hg.conf,` it is set up to create a salt state that manages `ratelimit.conf`, installs `mod_qos`package, uses symlinks to define and enable `mod_qos`, and loads configuration data from pillar. 

To verify and test these changes locally,

1. bring up the salt-master, `laptop:psf-salt user$ vagrant up salt-master`
2. bring up the loadbalancer, `laptop:psf-salt user$ vagrant up loadbalancer`
3. bring up hg, `laptop:psf-salt user$ vagrant up hg`
4. in another window, ssh into the vagrant hg box, `laptop:psf-salt user$  vagrant ssh hg`
5. in the vagrant box, install curl `sudo apt install curl`
6. in the vagrant box, run the command `for i in {1..10}; do curl -o /dev/null -s -w "%{http_code}\n" -k -H "Host: hg.python.org" https://127.0.0.1:9000/; done` 

Next steps to configure our loadbalancer as a [privileged user](https://mod-qos.sourceforge.net/#privilegedusers) to prevent it from getting rate limited. 

This PR now includes a configuration which attempts to establsih our loadbalancer as a VIP user, however the loadbalancer is still getting rate limited where we would otherwise expect it to have no limit. To recreate this, follow the above steps and additionally include testing for our LB (below). 

7.  in the vagrant box, run the command `for i in {1..10}; do curl -o /dev/null -s -w "%{http_code}\n" -k -H "Host: hg.python.org" https://192.168.50.19/; done`

Included in this PR is a commented out block of code which attempts to use `SrvMaxÇonnExcludeIP` to achieve the same goal, but this also is not producing the expected outcome. Although, after reading over `mod-qos` docs I believe that this may be because this directive is considered a connection level control directive, whereas we are using client level control directives to establish rate limiting. 