### PR TITLE
Prepare Salt-Master for Migration

### DIFF
--- a/pillar/base/haproxy.sls
+++ b/pillar/base/haproxy.sls
@@ -95,13 +95,13 @@ haproxy:
     letsencrypt-well-known:
       domains: []
       verify_host: salt.psf.io
-      check: "GET /.well-known/acme-challenge/sentinel HTTP/1.1\\r\\nHost:\\ salt.psf.io"
+      check: "GET /.well-known/acme-challenge/sentinel-fail HTTP/1.1\\r\\nHost:\\ salt.psf.io" 
 
     publish-files:
       domains:
         - salt-public.psf.io
       verify_host: salt.psf.io
-      check: "GET /salt-server-list.rst HTTP/1.1\\r\\nHost:\\ salt-public.psf.io"
+      check: "GET /salt-server-list-fail.rst HTTP/1.1\\r\\nHost:\\ salt-public.psf.io"
 
   redirects:
     cheeseshop.python.org:


### PR DESCRIPTION
This PR prepares the salt-master to be migrated to a new upgraded host, by reconfiguring a failing health check. The pillar data for the salt-master in `/pillar/prod/roles.sls` already includes both old and new hostnames by matching a pattern of `salt*.nyc1.psf.io`