### PR TITLE
Provision the salt-master to run using Ubuntu 22.04 codename: jammy 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ SERVERS = [
   "buildbot",
   "cdn-logs",
   "codespeed",
-  "consul",
+  {:name => "consul", :codename => "jammy"},
   "docs",
   "downloads",
   "hg",
@@ -46,10 +46,10 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "salt-master" do |s_config|
     # Uncomment below to migrate salt-master to jammy
-    # s_config.vm.provider "docker" do |docker, override|
-    #   docker.build_dir = "dockerfiles"
-    #   docker.dockerfile = "Dockerfile.jammy"
-    # end
+    s_config.vm.provider "docker" do |docker, override|
+      docker.build_dir = "dockerfiles"
+      docker.dockerfile = "Dockerfile.jammy"
+    end
 
     s_config.vm.hostname = "salt-master.vagrant.psf.io"
     s_config.vm.network "private_network", ip: MASTER1

--- a/dockerfiles/Dockerfile.jammy
+++ b/dockerfiles/Dockerfile.jammy
@@ -21,8 +21,9 @@ ENV LC_ALL en_US.UTF-8
 
 COPY ./etc/ssl/private/dhparams.pem /etc/ssl/private/dhparams.pem
 
-# Install Vim
+# Install Vim and Curl
 RUN apt-get install -y vim
+RUN apt-get install -y curl
 
 # Needed to run systemd
 # VOLUME [ "/sys/fs/cgroup" ]
@@ -48,8 +49,8 @@ RUN /usr/sbin/sshd
 
 # Setup Salt Common
 
-RUN wget --quiet -O /usr/share/keyrings/salt-archive-keyring.gpg https://repo.saltproject.io/py3/ubuntu/20.04/$(dpkg --print-architecture)/3004/salt-archive-keyring.gpg
-RUN echo "deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://repo.saltproject.io/py3/ubuntu/20.04/$(dpkg --print-architecture)/3004 focal main" > /etc/apt/sources.list.d/salt.list
+RUN sudo curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring-2023.gpg https://repo.saltproject.io/salt/py3/ubuntu/22.04/$(dpkg --print-architecture)/SALT-PROJECT-GPG-PUBKEY-2023.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch=$(dpkg --print-architecture)] https://repo.saltproject.io/salt/py3/ubuntu/22.04/$(dpkg --print-architecture)/latest jammy main" | sudo tee /etc/apt/sources.list.d/salt.list
 RUN apt-get update -y && apt-get install -y --no-install-recommends salt-minion
 
 # Start Systemd (systemctl)


### PR DESCRIPTION
WIP: This PR introduces necessary changes to provision the salt-master to run using Ubuntu 22.04. It also upgrades our salt stack version to run as the latest version (3006.5). Upon provisioning the salt-master in a vagrant box, currently, salt gets stuck waiting for consul, and consul doesn't get installed via salt.

Next steps: Figure out why consul is not installing via salt, but is able to install via the command line. 