### PR TITLE
Migrate salt-master to Ubuntu 22.04('Jammy')

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ SERVERS = [
   "buildbot",
   "cdn-logs",
   "codespeed",
-  "consul",
+  {:name => "consul", :codename => "jammy"},
   "docs",
   "downloads",
   "hg",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,10 +41,10 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "salt-master" do |s_config|
     # Uncomment below to migrate salt-master to jammy
-    # s_config.vm.provider "docker" do |docker, override|
-    #   docker.build_dir = "dockerfiles"
-    #   docker.dockerfile = "Dockerfile.jammy"
-    # end
+     s_config.vm.provider "docker" do |docker, override|
+       docker.build_dir = "dockerfiles"
+       docker.dockerfile = "Dockerfile.jammy"
+     end
 
     s_config.vm.hostname = "salt-master.vagrant.psf.io"
     s_config.vm.network "private_network", ip: MASTER1

--- a/conf/vagrant/master.conf
+++ b/conf/vagrant/master.conf
@@ -4,6 +4,8 @@ failhard: True
 
 extension_modules: srv/salt/_extensions
 
+user: root
+
 pillar_roots:
   base:
     - /srv/pillar/dev

--- a/salt/base/salt.sls
+++ b/salt/base/salt.sls
@@ -34,6 +34,9 @@ salt-2018.3:
     {% if grains["oscodename"] == "focal" %}
     - name: deb https://archive.repo.saltproject.io/py3/ubuntu/20.04/{{ grains["osarch"] }}/archive/3004 focal main
     - key_url: https://archive.repo.saltproject.io/py3/ubuntu/20.04/{{ grains["osarch"] }}/archive/3004/salt-archive-keyring.gpg
+    {% elif grains["oscodename"] == "jammy" %}
+    - name: deb https://repo.saltproject.io/salt/py3/ubuntu/22.04/{{ grains["osarch"] }}/latest jammy main
+    - key_url: https://repo.saltproject.io/salt/py3/ubuntu/22.04/{{ grains["osarch"] }}/SALT-PROJECT-GPG-PUBKEY-2023.gpg
     {% else %}
     - name: deb http://archive.repo.saltstack.com/py3/ubuntu/{{ grains["osrelease"] }}/{{ grains["osarch"] }}/2018.3 {{ grains["oscodename"] }} main
     - key_url: https://archive.repo.saltstack.com/py3/ubuntu/18.04/amd64/2018.3/SALTSTACK-GPG-KEY.pub

--- a/salt/base/salt.sls
+++ b/salt/base/salt.sls
@@ -6,6 +6,16 @@ python-requests:
 python-msgpack:
   pkg.latest:
     - name: python3-msgpack
+
+{% elif grains["oscodename"] == "jammy" %}
+python-requests:
+  pkg.latest:
+    - name: python3-requests
+
+python-msgpack:
+  pkg.latest:
+    - name: python3-msgpack
+
 {% else %}
 python-requests:
   pkg.latest


### PR DESCRIPTION
This PR migrates our salt-master to run on Ubuntu 22.04, codename "Jammy." 

In our previous configuration running salt 3004, the salt-master ran as the root user. In the [latest release,](https://docs.saltproject.io/en/master/topics/releases/3006.0.html#:~:text=The%20linux%20Salt%20Master%20packages%20will%20now%20add%20a%20Salt%20user%20and%20group%20by%20default.) the salt-master adds a "salt" user and group by default, and runs as the "salt" user. By adding `user: root` to out vagrant `master.conf` file, we allow the salt-master to run as root, like we had previously done, and bypass permissions errors related to loading `ca.py` and `consul.py` modules.

This PR also conditionally updates our configuration to use the [onedir packaging ](https://docs.saltproject.io/salt/install-guide/en/latest/topics/upgrade-to-onedir.html)with codename "jammy" updating the repo URL, path names, and GPG key. 

To verify this locally:
1. bring up the salt-master, `laptop:psf-salt user$ vagrant up salt-master`
2. bring up the loadbalancer, `laptop:psf-salt user$ vagrant up loadbalancer`
3. bring up a backend service like hg, `laptop:psf-salt user$ vagrant up hg`

The traceback for the salt-master should show it running on jammy, but to further verify the upgrade:
1. in another window, ssh into the salt-master, `laptop:psf-salt user$  vagrant ssh salt-master`
2. run the command `lsb_release -a` 
```Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.3 LTS
Release:	22.04
Codename:	jammy
```