### PR TITLE
guard older distros from jammy aptkey support

### DIFF
--- a/salt/base/repo.sls
+++ b/salt/base/repo.sls
@@ -1,16 +1,13 @@
-/etc/apt/keys:
-  file.directory:
-    - user: root
-    - group: root
-    - dir_mode: "0755"
-    - file_mode: "0644"
-
 psf:
   pkgrepo.managed:
+    {% if grains["oscodename"] == "jammy" %}
     - name: "deb [signed-by=/etc/apt/keyrings/packagecloud.gpg arch={{ grains["osarch"] }}] https://packagecloud.io/psf/infra/ubuntu {{ grains['oscodename'] }} main"
+    - aptkey: False
+    {% else %}
+    - name: "deb https://packagecloud.io/psf/infra/ubuntu {{ grains['oscodename'] }} main"
+    {% endif %}
     - file: /etc/apt/sources.list.d/psf.list
     - key_url: salt://base/config/APT-GPG-KEY-PSF
-    - aptkey: False
 
 # Make source list globally readable.
 /etc/apt/sources.list.d/psf.list:

--- a/salt/datadog/init.sls
+++ b/salt/datadog/init.sls
@@ -1,9 +1,13 @@
 datadog_repo:
   pkgrepo.managed:
+    {% if grains["oscodename"] == "jammy" %}
     - name: "deb [signed-by=/etc/apt/keyrings/datadoghq.gpg arch={{ grains["osarch"] }}]  https://apt.datadoghq.com stable 6"
-    - file: /etc/apt/sources.list.d/datadog.list
-    - key_url: salt://datadog/config/APT-GPG-KEY-DATADOG
     - aptkey: False
+    {% else %}
+    - name: "deb https://apt.datadoghq.com stable 6"
+    {% endif %}
+    - key_url: salt://datadog/config/APT-GPG-KEY-DATADOG
+    - file: /etc/apt/sources.list.d/datadog.list
 
 {% set in_datadog_tags = pillar.get('datadog_tags', []) + grains.get('datadog_tags', []) + grains.get('datadog_tags_from_metadata', []) %}
 {% set datadog_tags = [] %}

--- a/salt/nginx/init.sls
+++ b/salt/nginx/init.sls
@@ -1,9 +1,13 @@
 nginx:
   pkgrepo.managed:
+    {% if grains["oscodename"] == "jammy" %}
     - name: deb [signed-by=/etc/apt/keyrings/nginx.gpg arch={{ grains["osarch"] }}] http://nginx.org/packages/ubuntu {{ grains.oscodename }} nginx
+    - aptkey: False
+    {% else %}
+    - name: deb http://nginx.org/packages/ubuntu {{ grains.oscodename }} nginx
+    {% endif %}
     - file: /etc/apt/sources.list.d/nginx.list
     - key_url: salt://nginx/config/APT-GPG-KEY-NGINX
-    - aptkey: False
     - order: 2
     - require_in:
       - pkg: nginx


### PR DESCRIPTION
older versions of Ubuntu that we currently support/run do not play nicely with the changes added to address apt-key deprecation.

this guards the new changes and applies them only to jammy boxes