### PR TITLE
cdn-logs: ensure adm group is applied to fastly logs

### DIFF
--- a/salt/cdn-logs/init.sls
+++ b/salt/cdn-logs/init.sls
@@ -1,3 +1,7 @@
+adm:
+  group.present:
+    - name: adm
+
 /var/log/fastly/:
   file.directory:
     - user: syslog


### PR DESCRIPTION
The `adm` group is used to control access to reading streamed logs, but isn't available for salt to fulfill the requisite.