### PR TITLE
buildbot: Remove /all redirect

### DIFF
--- a/salt/buildbot/config/nginx.conf.jinja
+++ b/salt/buildbot/config/nginx.conf.jinja
@@ -27,8 +27,6 @@ server {
   rewrite ^/3.x.stable(/?)$ /#/grid?branch=main&tag=stable redirect;
   rewrite ^/stable(/?)$ /#/grid?tag=stable redirect;
 
-  rewrite ^/all/(.*)$ /$1 redirect;
-
   location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;


### PR DESCRIPTION
It's already rewritten out in the location / config.
