### PR TITLE
feat(noble): add firewall rules for noble host migration

### DIFF
--- a/pillar/base/firewall/salt.sls
+++ b/pillar/base/firewall/salt.sls
@@ -6,26 +6,28 @@ firewall:
     port: 9000:9001
     source: *psf_internal_network
 
-  salt_master_bugs_ams1:
-    port: 4505:4506
-    source: 188.166.48.69
-
-  salt_master_mail1_ams1:
-    port: 4505:4506
-    source: 188.166.95.178
-
   salt_master_psf_internal:
     port: 4505:4506
     source: *psf_internal_network
 
+  {# NOTE: These hosts do not run in the primary DC (NYC1) so firewall holes are poked for access #}
   salt_master_pythontest:
     port: 4505:4506
     source: 159.89.235.38
+
+  salt_master_pythontest_noble:
+    port: 4505:4506
+    source: 68.183.26.59
 
   salt_master_remote_backup:
     port: 4505:4506
     source: 138.68.57.99
 
+  salt_master_mail1_ams1:
+    port: 4505:4506
+    source: 188.166.95.178
+
+  {# TODO: this is used in development environments #}
   salt_master_pebble:
     port: 14000
     source: *psf_internal_network


### PR DESCRIPTION
## What

- Adds firewall rules for host living outside of primary DC (NYC1)