### PR TITLE
fix(base): disable ntp installed on noble

### DIFF
--- a/salt/base/sanity.sls
+++ b/salt/base/sanity.sls
@@ -5,6 +5,7 @@ niceties:
       - htop
       - traceroute
 
+{% if grains["oscodename"] != "noble" %}
 time-sync:
   pkg.installed:
     - pkgs:
@@ -15,7 +16,7 @@ ntp:
   service:
     - running
     - enable: True
-
+{% endif %}
 
 # Cron has a default $PATH of only /usr/bin:/bin, however the root user's
 # default $PATH in the shell includes various sbin directories. This can cause

--- a/salt/base/sanity.sls
+++ b/salt/base/sanity.sls
@@ -16,7 +16,7 @@ systemd-timesyncd:
     - running
     - enable: True
 {% else %}
-time-sync-ntp
+time-sync-ntp:
   pkg.installed:
     - pkgs:
       - ntp

--- a/salt/base/sanity.sls
+++ b/salt/base/sanity.sls
@@ -10,8 +10,12 @@ systemd-timesyncd:
    pkg:
      - installed
    service:
+     {% if grains["detect_virt"] in ["docker"] %}
+     - enabled
+     {% else %}
      - running
      - enable: True
+    {% endif %}
 {% else %}
 ntp-packages:
   pkg.installed:

--- a/salt/base/sanity.sls
+++ b/salt/base/sanity.sls
@@ -5,8 +5,18 @@ niceties:
       - htop
       - traceroute
 
-{% if grains["oscodename"] != "noble" %}
-time-sync:
+{% if grains["oscodename"] in ["noble"] %}
+time-sync-timesyncd:
+    pkg.installed:
+      - pkgs:
+        - systemd-timesyncd
+
+systemd-timesyncd:
+  service:
+    - running
+    - enable: True
+{% else %}
+time-sync-ntp
   pkg.installed:
     - pkgs:
       - ntp

--- a/salt/base/sanity.sls
+++ b/salt/base/sanity.sls
@@ -6,17 +6,14 @@ niceties:
       - traceroute
 
 {% if grains["oscodename"] in ["noble"] %}
-time-sync-timesyncd:
-    pkg.installed:
-      - pkgs:
-        - systemd-timesyncd
-
 systemd-timesyncd:
-  service:
-    - running
-    - enable: True
+   pkg:
+     - installed
+   service:
+     - running
+     - enable: True
 {% else %}
-time-sync-ntp:
+ntp-packages:
   pkg.installed:
     - pkgs:
       - ntp


### PR DESCRIPTION
## What

- Does not install ntp on noble as it uses timesyncd as an ntp client and running highstate in production causes conflicts