### PR TITLE
implement a `detect_virt` grain

### DIFF
--- a/salt/_grains/detect_virt.py
+++ b/salt/_grains/detect_virt.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import subprocess
+
+
+def main():
+    try:
+        result = subprocess.run(
+            ["/usr/bin/systemd-detect-virt"], stdout=subprocess.PIPE, check=True
+        ).stdout.rstrip()
+    except FileNotFoundError:
+        result = "unknown"
+    return {"detect_virt": result}


### PR DESCRIPTION
This is useful for things we may not want or be able to run when operating in a docker container.

Specific example is systemd-timesyncd, which refuses to start in a container:

```
[Unit]
Description=Network Time Synchronization
Documentation=man:systemd-timesyncd.service(8)
ConditionCapability=CAP_SYS_TIME
ConditionVirtualization=!container
DefaultDependencies=no
...
```

Note the `ConditionVirtualization` blocking.

Useful state might be something like:

```
systemd-timesyncd:
  pkg:
    - installed
  service:
    - enabled
    {% if grains["detect_virt"] not in ["docker"] %}
    - running
    {% endif %}
```

Which would _enable_ the service but not fail when it fails to start.