### PR TITLE
chore(#399): remove `cia.vc` domain

### DIFF
--- a/pillar/base/bugs.sls
+++ b/pillar/base/bugs.sls
@@ -32,7 +32,6 @@ bugs:
             spambayes_uri: "http://localhost:8001/sbrpc"
             spambayes_ham_cutoff: "0.2"
             spambayes_spam_cutoff: "0.85"
-            ciavc_server: "https://python.org"
       accept_email: False
       email_reject_message: "This tracker is in read-only mode. Please use GitHub issues to open a ticket: https://github.com/python/cpython/issues"
     jython:

--- a/pillar/base/bugs.sls
+++ b/pillar/base/bugs.sls
@@ -32,7 +32,7 @@ bugs:
             spambayes_uri: "http://localhost:8001/sbrpc"
             spambayes_ham_cutoff: "0.2"
             spambayes_spam_cutoff: "0.85"
-            ciavc_server: "http://CIA.vc"
+            ciavc_server: "https://python.org"
       accept_email: False
       email_reject_message: "This tracker is in read-only mode. Please use GitHub issues to open a ticket: https://github.com/python/cpython/issues"
     jython:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Renames the now stale URL for the retired cia.vc service. The domain has since been repurposed and is pointing to advertisements.

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- Closes #399

