### PR TITLE
fix(bugs): fix smtp haproxy config, allow smtp through lb firewall

### DIFF
--- a/pillar/base/firewall/loadbalancer.sls
+++ b/pillar/base/firewall/loadbalancer.sls
@@ -34,3 +34,6 @@ firewall:
 
   "buildbot.python.org:worker":
     port: 9020
+
+  "bugs.python.org:smtp":
+    port: 20025

--- a/pillar/base/haproxy.sls
+++ b/pillar/base/haproxy.sls
@@ -167,7 +167,7 @@ haproxy:
         - timeout server 86400
 
     {# We can extend this for smtps/submission later #}
-    {% for (port, service, ssl) in [(25, "smtp", False)] %}
+    {% for (port, service, ssl) in [(20025, "smtp", False)] %}
     roundup-{{ service }}:
       bind: :{{ port }} {% if ssl %} ssl crt /etc/ssl/private/bugs.python.org.pem {% endif %}
       service: roundup-{{ service }}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Fixes SMTP access with loadbalancers firewalls
- Corrects SMTP port for haproxy
