### PR TITLE
Proxy protocol

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ SERVERS = [
   "docs",
   "downloads",
   "hg",
-  {:name => "loadbalancer", :ports => [20000, 20001, 20002, 20003, 20004, 20005, 20010]},
+  {:name => "loadbalancer", :ports => [20000, 20001, 20002, 20003, 20004, 20005, 20010, 20011]},
   "mail",
   "moin",
   "planet",

--- a/pillar/base/firewall/bugs.sls
+++ b/pillar/base/firewall/bugs.sls
@@ -10,3 +10,6 @@ firewall:
   frontend-bugs:
     port: 9000:9002
     source: *psf_internal_network
+  postscreen:
+    port: 20025
+    source: *psf_internal_network

--- a/pillar/base/firewall/loadbalancer.sls
+++ b/pillar/base/firewall/loadbalancer.sls
@@ -8,9 +8,6 @@ firewall:
   http_0:
     port: 20000
 
-  http_1:
-    port: 20001
-
   http_2:
     port: 20002
 
@@ -28,6 +25,12 @@ firewall:
 
   http_map:
     port: 20010
+
+  http_proxy:
+    port: 20001
+
+  http_proxy_map:
+    port: 20011
 
   "hg.python.org:ssh":
     port: 20100

--- a/pillar/base/haproxy.sls
+++ b/pillar/base/haproxy.sls
@@ -171,6 +171,8 @@ haproxy:
     roundup-{{ service }}:
       bind: :{{ port }} {% if ssl %} ssl crt /etc/ssl/private/bugs.python.org.pem {% endif %}
       service: roundup-{{ service }}
+      accept_proxy: True
+      send_proxy: True
       extra:
         - timeout client 30m
         - timeout server 30m

--- a/salt/bugs/config/postfix/main.cf
+++ b/salt/bugs/config/postfix/main.cf
@@ -50,3 +50,6 @@ virtual_alias_domains = {% for tracker, config in pillar["bugs"]["trackers"].ite
 virtual_alias_maps = hash:/etc/postfix/virtual
 
 smtpd_recipient_restrictions = check_recipient_access hash:/etc/postfix/reject_recipients
+
+postscreen_upstream_proxy_protocol = haproxy
+postscreen_upstream_proxy_timeout = 5s

--- a/salt/bugs/config/postfix/master.cf
+++ b/salt/bugs/config/postfix/master.cf
@@ -1,0 +1,130 @@
+#
+# Postfix master process configuration file.  For details on the format
+# of the file, see the master(5) manual page (command: "man 5 master" or
+# on-line: http://www.postfix.org/master.5.html).
+#
+# Do not forget to execute "postfix reload" after editing this file.
+#
+# ==========================================================================
+# service type  private unpriv  chroot  wakeup  maxproc command + args
+#               (yes)   (yes)   (no)    (never) (100)
+# ==========================================================================
+smtp      inet  n       -       y       -       -       smtpd
+20025     inet  n       -       y       -       1       postscreen
+#smtp      inet  n       -       y       -       1       postscreen
+smtpd     pass  -       -       y       -       -       smtpd
+#dnsblog   unix  -       -       y       -       0       dnsblog
+#tlsproxy  unix  -       -       y       -       0       tlsproxy
+# Choose one: enable submission for loopback clients only, or for any client.
+#127.0.0.1:submission inet n -   y       -       -       smtpd
+#submission inet n       -       y       -       -       smtpd
+#  -o syslog_name=postfix/submission
+#  -o smtpd_tls_security_level=encrypt
+#  -o smtpd_sasl_auth_enable=yes
+#  -o smtpd_tls_auth_only=yes
+#  -o smtpd_reject_unlisted_recipient=no
+#  -o smtpd_client_restrictions=$mua_client_restrictions
+#  -o smtpd_helo_restrictions=$mua_helo_restrictions
+#  -o smtpd_sender_restrictions=$mua_sender_restrictions
+#  -o smtpd_recipient_restrictions=
+#  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#  -o milter_macro_daemon_name=ORIGINATING
+# Choose one: enable smtps for loopback clients only, or for any client.
+#127.0.0.1:smtps inet n  -       y       -       -       smtpd
+#smtps     inet  n       -       y       -       -       smtpd
+#  -o syslog_name=postfix/smtps
+#  -o smtpd_tls_wrappermode=yes
+#  -o smtpd_sasl_auth_enable=yes
+#  -o smtpd_reject_unlisted_recipient=no
+#  -o smtpd_client_restrictions=$mua_client_restrictions
+#  -o smtpd_helo_restrictions=$mua_helo_restrictions
+#  -o smtpd_sender_restrictions=$mua_sender_restrictions
+#  -o smtpd_recipient_restrictions=
+#  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#  -o milter_macro_daemon_name=ORIGINATING
+#628       inet  n       -       y       -       -       qmqpd
+pickup    unix  n       -       y       60      1       pickup
+cleanup   unix  n       -       y       -       0       cleanup
+qmgr      unix  n       -       n       300     1       qmgr
+#qmgr     unix  n       -       n       300     1       oqmgr
+tlsmgr    unix  -       -       y       1000?   1       tlsmgr
+rewrite   unix  -       -       y       -       -       trivial-rewrite
+bounce    unix  -       -       y       -       0       bounce
+defer     unix  -       -       y       -       0       bounce
+trace     unix  -       -       y       -       0       bounce
+verify    unix  -       -       y       -       1       verify
+flush     unix  n       -       y       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+proxywrite unix -       -       n       -       1       proxymap
+smtp      unix  -       -       y       -       -       smtp
+relay     unix  -       -       y       -       -       smtp
+        -o syslog_name=postfix/$service_name
+#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+showq     unix  n       -       y       -       -       showq
+error     unix  -       -       y       -       -       error
+retry     unix  -       -       y       -       -       error
+discard   unix  -       -       y       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       y       -       -       lmtp
+anvil     unix  -       -       y       -       1       anvil
+scache    unix  -       -       y       -       1       scache
+postlog   unix-dgram n  -       n       -       1       postlogd
+#
+# ====================================================================
+# Interfaces to non-Postfix software. Be sure to examine the manual
+# pages of the non-Postfix software to find out what options it wants.
+#
+# Many of the following services use the Postfix pipe(8) delivery
+# agent.  See the pipe(8) man page for information about ${recipient}
+# and other message envelope options.
+# ====================================================================
+#
+# maildrop. See the Postfix MAILDROP_README file for details.
+# Also specify in main.cf: maildrop_destination_recipient_limit=1
+#
+maildrop  unix  -       n       n       -       -       pipe
+  flags=DRXhu user=vmail argv=/usr/bin/maildrop -d ${recipient}
+#
+# ====================================================================
+#
+# Recent Cyrus versions can use the existing "lmtp" master.cf entry.
+#
+# Specify in cyrus.conf:
+#   lmtp    cmd="lmtpd -a" listen="localhost:lmtp" proto=tcp4
+#
+# Specify in main.cf one or more of the following:
+#  mailbox_transport = lmtp:inet:localhost
+#  virtual_transport = lmtp:inet:localhost
+#
+# ====================================================================
+#
+# Cyrus 2.1.5 (Amos Gouaux)
+# Also specify in main.cf: cyrus_destination_recipient_limit=1
+#
+#cyrus     unix  -       n       n       -       -       pipe
+#  flags=DRX user=cyrus argv=/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
+#
+# ====================================================================
+# Old example of delivery via Cyrus.
+#
+#old-cyrus unix  -       n       n       -       -       pipe
+#  flags=R user=cyrus argv=/cyrus/bin/deliver -e -m ${extension} ${user}
+#
+# ====================================================================
+#
+# See the Postfix UUCP_README file for configuration details.
+#
+uucp      unix  -       n       n       -       -       pipe
+  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#
+# Other external delivery methods.
+#
+ifmail    unix  -       n       n       -       -       pipe
+  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+bsmtp     unix  -       n       n       -       -       pipe
+  flags=Fq. user=bsmtp argv=/usr/lib/bsmtp/bsmtp -t$nexthop -f$sender $recipient
+scalemail-backend unix -       n       n       -       2       pipe
+  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store ${nexthop} ${user} ${extension}
+mailman   unix  -       n       n       -       -       pipe
+  flags=FRX user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py ${nexthop} ${user}

--- a/salt/bugs/init.sls
+++ b/salt/bugs/init.sls
@@ -165,6 +165,17 @@ tracker-nginx-extras:
       - pkg: roundup-deps
       - cmd: lego_bootstrap
 
+/etc/postfix/master.cf:
+  file.managed:
+    - source: salt://bugs/config/postfix/master.cf
+    - user: root
+    - group: root
+    - mode: "0644"
+    - template: jinja
+    - require:
+      - pkg: roundup-deps
+      - cmd: lego_bootstrap
+
 /etc/postfix/virtual:
   file.managed:
     - source: salt://bugs/config/postfix/virtual
@@ -203,15 +214,17 @@ postfix:
     - reload: True
     - require:
       - file: /etc/postfix/main.cf
+      - file: /etc/postfix/master.cf
       - file: /etc/postfix/virtual
       - file: /etc/postfix/reject_recipients
     - watch_any:
       - file: /etc/postfix/main.cf
+      - file: /etc/postfix/master.cf
       - file: /etc/postfix/virtual
       - file: /etc/postfix/reject_recipients
 
 {# We can extend this for smtps/submission later #}
-{% for (port, service) in [(25, "smtp")] %}
+{% for (port, service) in [(20025, "smtp")] %}
 /etc/consul.d/roundup-{{ service }}.json:
   file.managed:
     - source: salt://consul/etc/service.jinja

--- a/salt/haproxy/config/haproxy.cfg.jinja
+++ b/salt/haproxy/config/haproxy.cfg.jinja
@@ -89,6 +89,7 @@ listen tls:
     bind 0.0.0.0:443 ssl alpn h2,http/1.1 crt star.python.org.pem crt star.pypa.io.pem crt star.pyfound.org.pem crt speed.pypy.org.pem crt www.pycon.org.pem crt jython.org.pem crt salt-public.psf.io.pem crt planetpython.org.pem crt bugs.python.org.pem
     bind :::443 ssl alpn h2,http/1.1 crt star.python.org.pem crt star.pypa.io.pem crt star.pyfound.org.pem  crt speed.pypy.org.pem crt www.pycon.org.pem crt jython.org.pem crt salt-public.psf.io.pem crt planetpython.org.pem crt bugs.python.org.pem
     bind :20010 ssl alpn h2,http/1.1 crt star.python.org.pem crt star.pypa.io.pem crt star.pyfound.org.pem crt speed.pypy.org.pem crt www.pycon.org.pem crt jython.org.pem crt salt-public.psf.io.pem crt planetpython.org.pem crt bugs.python.org.pem
+    bind :20011 accept-proxy ssl alpn h2,http/1.1 crt star.python.org.pem crt star.pypa.io.pem crt star.pyfound.org.pem crt speed.pypy.org.pem crt www.pycon.org.pem crt jython.org.pem crt salt-public.psf.io.pem crt planetpython.org.pem crt bugs.python.org.pem
 
     mode http
 
@@ -106,6 +107,7 @@ listen tls:
 
 frontend main
     bind :20000
+    bind :20001 accept-proxy
     bind 0.0.0.0:80
     bind :::80
     bind 127.0.0.1:19001  # This is our TLS socket.
@@ -236,7 +238,7 @@ backend {{ service }}
 
 {% for name, config in haproxy.listens.items() -%}
 listen {{ name }}
-    bind {{ config.bind }}
+    bind {{ config.bind }}{% if config.get("accept_proxy", False) %} accept-proxy{% endif %}
 
     mode tcp
     option tcplog
@@ -247,7 +249,7 @@ listen {{ name }}
     {% endfor %}
 
     {{ "{{" }}range service "{{ config.service }}@{{ pillar.dc }}"}}
-    {% raw %}server {{.Node}} {{.Address}}:{{.Port}} check{{end}}{% endraw %}
+    {% raw %}server {{.Node}} {{.Address}}:{{.Port}} check{{end}}{% endraw %}{% if config.get("send_proxy", False) %} send-proxy{% endif %}
 
 {% endfor %}
 


### PR DESCRIPTION
## Description

This enables our haproxy instances to accept proxy protocol. This will be necessary so that we can get actual client ip addresses to the backends when requests traverse the Digital Ocean load balancers.

As is, haproxy _only_ sees the client address as the DO load balancer when clients hit it directly. With this, we can enable Proxy Protocol on the DO load balancer and send the actual client ip along.