### PR TITLE
fix(datadog): install datadog signing keys package before agent

### DIFF
--- a/salt/datadog/init.sls
+++ b/salt/datadog/init.sls
@@ -35,6 +35,7 @@ datadog-agent:
   pkg:
     - installed
     - require:
+      - pkg: datadog-signing-keys
       - pkgrepo: datadog_repo
   service:
     - running


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Fixes issue with `pythontest` installing nginx and requiring manual intervention
