### PR TITLE
feat(docs): add autobuild and serving for docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+PIP_COMMAND 	:= $(shell command -v uv >/dev/null 2>&1 && echo "uv pip" || echo "pip")
+ENV_PREFIX		=  .venv/bin/
+
+docs-install: 										## Install docs dependencies
+	@echo "=> Installing documentation dependencies"
+	@$(PIP_COMMAND) install -r docs/requirements.txt
+	@echo "=> Installed documentation dependencies"
+
+docs-clean: 										## Dump the existing built docs
+	@echo "=> Cleaning documentation build assets"
+	@rm -rf docs/_build
+	@echo "=> Removed existing documentation build assets"
+
+docs-serve: docs-clean docs-install							## Serve the docs locally
+	@echo "=> Serving documentation"
+	@$(ENV_PREFIX)sphinx-autobuild docs/ docs/_build/ -j auto --watch docs/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ furo
 sphinx
 myst-parser
 sphinx-copybutton
+sphinx-autobuild


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Adds `sphinx-autobuild` to build and serve the documentation
- Adds a top level Makefile with targets to install docs deps and serve the docs via `make docs-serve`


## Preview
```
psf-salt on  #364 [📝++(1)🤷] via  pyenv via ⍱ v2.4.1 
󰂃 7% ✗make docs-serve
=> Cleaning documentation build assets
=> Removed existing documentation build assets
=> Installing documentation dependencies
Audited 5 packages in 24ms
=> Installed documentation dependencies
=> Serving documentation
[sphinx-autobuild] Starting initial build
[sphinx-autobuild] > sphinx-build docs/ docs/_build/ -j auto
Running Sphinx v7.3.7
myst v3.0.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 16 source files that are out of date
updating environment: [new config] 16 added, 0 changed, 0 removed
reading sources... [100%] ssl
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] ssl
generating indices... genindex done
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in docs/_build.
[sphinx-autobuild] Serving on http://127.0.0.1:8000
[sphinx-autobuild] Waiting to detect changes...

```

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- Closes #364

