### PR TITLE
fix(hg): add svn backup configs required for new host setup

### DIFF
--- a/pillar/prod/backup/hg.sls
+++ b/pillar/prod/backup/hg.sls
@@ -14,3 +14,10 @@ backup:
       target_user: root
       frequency: daily
       user: root
+    hg-svn-config:
+      source_directory: /etc/apache2/svn_config/
+      target_host: backup.sfo1.psf.io
+      target_directory: /backup/hg-svn-config
+      target_user: root
+      frequency: daily
+      user: root


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Adds `svn` config dir to backups


