### PR TITLE
fix(pythontest): add `nonexistent/` dir

### DIFF
--- a/salt/pythontest/init.sls
+++ b/salt/pythontest/init.sls
@@ -46,6 +46,12 @@ inn2:
     - user: www-data
     - group: www-data
 
+/nonexistent:
+  file.directory:
+    - user: nginx
+    - group: nginx
+    - mode: 755
+
 testdata-repo:
   git.latest:
     - name: https://github.com/python/pythontestdotnet

--- a/salt/pythontest/init.sls
+++ b/salt/pythontest/init.sls
@@ -50,7 +50,7 @@ inn2:
   file.directory:
     - user: nginx
     - group: nginx
-    - mode: 755
+    - mode: "0755"
 
 testdata-repo:
   git.latest:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Adds a state to create the `/nonexistent/` directory used by FTP and/or NGINX based on the old host:
```
coffee@pythontest:/nonexistent$ stat .
  File: .
  Size: 4096            Blocks: 8          IO Block: 4096   directory
Device: fc01h/64513d    Inode: 2580481     Links: 2
Access: (0755/drwxr-xr-x)  Uid: (  113/   nginx)   Gid: (  118/   nginx)
Access: 2024-08-07 19:04:29.518055247 +0000
Modify: 2019-02-26 19:51:29.958493645 +0000
Change: 2019-02-26 19:51:29.962493645 +0000
 Birth: -
```