### PR TITLE
fix(buildbot): ensure parent dirs exist

### DIFF
--- a/salt/buildbot/init.sls
+++ b/salt/buildbot/init.sls
@@ -36,6 +36,7 @@ buildbot-user:
     - user: buildbot
     - group: root
     - mode: "0755"
+    - makedirs: True
 
 /srv:
   file.directory:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Ensures parent directories exist
```
----------
ID: /data/www/buildbot
Function: file.directory
Result: False
Comment: No directory to create /data/www/buildbot in
Started: 16:28:20.978710
Duration: 1.918 ms
Changes:
----------
/data/www/buildbot:
----------
directory:
new
```

Build fast break fast :(