### PR TITLE
update rdiff-backup client call with new syntax

### DIFF
--- a/salt/backup/client/init.sls
+++ b/salt/backup/client/init.sls
@@ -38,7 +38,11 @@ include:
     - template: jinja
     - context:
         pre_script: '{{ config.get('pre_script', ":") }}'
+        {% if grains["oscodename"] == "noble" -%}
+        remote_command: '/usr/bin/rdiff-backup --terminal-verbosity 1 {%- for exclude in config.get('exclude', []) %} --exclude {{ exclude }} {%- endfor %} --remote-schema "ssh -i /etc/backup/.ssh/id_rsa_{{ backup }} -C %s rdiff-backup --server" backup --no-eas {{ config['source_directory'] }} {{ config['target_user'] }}@{{ config['target_host'] }}::{{ config['target_directory'] }}'
+        {% else %}
         remote_command: '/usr/bin/rdiff-backup --terminal-verbosity 1 {%- for exclude in config.get('exclude', []) %} --exclude {{ exclude }} {%- endfor %} --no-eas --remote-schema "ssh -i /etc/backup/.ssh/id_rsa_{{ backup }} -C %s rdiff-backup --server" {{ config['source_directory'] }} {{ config['target_user'] }}@{{ config['target_host'] }}::{{ config['target_directory'] }}'
+        {% endif %}
         post_script: '{{ config.get('post_script', ":") }}'
         cleanup_script: '{{ config.get('cleanup_script', ":") }}'
 


### PR DESCRIPTION
## Description

Looks like the version of rdiff-backup from noble emits warnings when run

```
WARNING: this command line interface is deprecated and will disappear, start using the new one as described with '--new --help'.
```

This address that.

_After_ we upgrade the backup server, we'll also need to edit the interior call. Filing #458 to track.