### PR TITLE
feat: require swap to run before datadoge

### DIFF
--- a/pillar/prod/swapfile.sls
+++ b/pillar/prod/swapfile.sls
@@ -1,3 +1,3 @@
-swapfile:
-  size: 1024
-  path: /swapfile
+swap_file:
+  swap_size: 1024
+  swap_path: /swapfile

--- a/salt/base/swap.sls
+++ b/salt/base/swap.sls
@@ -1,17 +1,17 @@
-{% set swapfile = salt["pillar.get"]("swapfile", {}) %}
-{% set size = swapfile.get("size", "1024") %}
-{% set path = swapfile.get("path") %}
+{% set swap_file = salt["pillar.get"]("swap_file", {}) %}
+{% set swap_size = swap_file.get("swap_size", "1024") %}
+{% set swap_path = swap_file.get("swap_path") %}
 
-{% if path %}
-{{ path }}:
+{% if swap_path %}
+{{ swap_path }}:
   cmd.run:
     - name: |
-        swapon --show=NAME --noheadings | grep -q "^{{ path }}$" && swapoff {{ path }}
-        rm -f {{ path }}
-        fallocate -l {{ size }}M {{ path }}
-        chmod 0600 {{ path }}
-        mkswap {{ path }}
-    - unless: bash -c "[[ $(($(stat -c %s {{ path }}) / 1024**2)) = {{ size }} ]]"
+        swapon --show=NAME --noheadings | grep -q "^{{ swap_path }}$" && swapoff {{ swap_path }}
+        rm -f {{ swap_path }}
+        fallocate -l {{ swap_size }}M {{ swap_path }}
+        chmod 0600 {{ swap_path }}
+        mkswap {{ swap_path }}
+    - unless: bash -c "[[ $(($(stat -c %s {{ swap_path }}) / 1024**2)) = {{ swap_size }} ]]"
 
   mount.swap:
     - persist: true

--- a/salt/datadog/init.sls
+++ b/salt/datadog/init.sls
@@ -36,7 +36,7 @@ datadog-agent:
     - installed
     - require:
       - pkgrepo: datadog_repo
-      - mount: {{ swap_path }}
+      - mount: {% if swap_path %}{{ swap_path }}{% endif %}
   service:
     - running
     - enable: True

--- a/salt/datadog/init.sls
+++ b/salt/datadog/init.sls
@@ -36,6 +36,7 @@ datadog-agent:
     - installed
     - require:
       - pkgrepo: datadog_repo
+      - mount: {{ swap_path }}
   service:
     - running
     - enable: True


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Requires swap state to run before the doge
- Renames some things to be non-generic
