### PR TITLE
fix: ensure datadog is in good state, fix swap file path check

### DIFF
--- a/salt/datadog/init.sls
+++ b/salt/datadog/init.sls
@@ -31,12 +31,25 @@ datadog_repo:
     - source: salt://datadog/files
 
 {% if 'datadog_api_key' in pillar %}
+check_datadog_installation:
+  cmd.run:
+    - name: |
+        if ! dpkg-query -W datadog-agent || ! test -f /etc/datadog-agent/datadog.yaml; then
+          dpkg --remove --force-remove-reinstreq datadog-agent || true
+          apt-get -y --fix-broken install
+          apt-get update
+        fi
+    - hide_output: True
+
 datadog-agent:
   pkg:
     - installed
     - require:
       - pkgrepo: datadog_repo
-      - mount: {% if swap_path %}{{ swap_path }}{% endif %}
+        {% if swap_path %}
+      - mount: {{ swap_path }}
+        {% endif %}
+      - cmd: check_datadog_installation
   service:
     - running
     - enable: True


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Adds check for datadog package half installed
 - ```
    root@consul-a-2404:~# stat /etc/datadog-agent/datadog.yaml
	stat: cannot statx '/etc/datadog-agent/datadog.yaml': No such file or directory
	root@consul-a-2404:~# dpkg --remove --force-remove-reinstreq datadog-agent || true
	dpkg: warning: overriding problem because --force enabled:
	dpkg: warning: package is in a very bad inconsistent state; you should
	 reinstall it before attempting a removal
	(Reading database ... 83527 files and directories currently installed.)
	Removing datadog-agent (1:6.53.0-1) ...
	root@consul-a-2404:~# apt-get -y --fix-broken install
	Reading package lists... Done
	Building dependency tree... Done
	Reading state information... Done
	0 upgraded, 0 newly installed, 0 to remove and 44 not upgraded. 
    ```
- Fixes path check (I think)