### PR TITLE
use git not hg for PyPy

### DIFF
--- a/pillar/base/codespeed.sls
+++ b/pillar/base/codespeed.sls
@@ -25,7 +25,7 @@ codespeed-instances:
     module: speed_pypy
     wsgi_app: speed_pypy.wsgi:application
     clones:
-      git: {}
-      hg:
+      git:
         pypy:
-          source: https://foss.heptapod.net/pypy/pypy
+          source: https://github.com/pypy/pypy
+      hg: {}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

PyPy has moved to git. This will make the logs show.

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

See for instance https://speed.pypy.org/changes/?rev=a02837db72&exe=8&env=3 which fails to display. I no longer have permissions to access the live logs to see if this is part of the problem, but locally this fixes the page.

