### PR TITLE
fix(planet): remove lego in favor of haproxy

### DIFF
--- a/salt/planet/config/nginx.planet.conf.jinja
+++ b/salt/planet/config/nginx.planet.conf.jinja
@@ -19,8 +19,10 @@ server {
     server_name {{ site }};
     error_log /var/log/nginx/{{ site }}.error.log;
     access_log /var/log/nginx/{{ site }}.access.log;
-    ssl_certificate /etc/lego/certificates/{{ grains['fqdn'] }}.crt;
-    ssl_certificate_key /etc/lego/certificates/{{ grains['fqdn'] }}.key;
+
+    # By default use the snakeoil certificate...
+    ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
+    ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
 
     root /srv/{{ site }}/;
 }

--- a/salt/planet/config/nginx.planet.conf.jinja
+++ b/salt/planet/config/nginx.planet.conf.jinja
@@ -1,33 +1,6 @@
 {% for site, info in salt["pillar.get"]("planet", {}).get("sites").items() %}
 
 server {
-    listen 80 default_server;
-    server_name {{ site }};
-
-    location /.well-known/acme-challenge/ {
-      alias /etc/lego/.well-known/acme-challenge/;
-      try_files $uri =404;
-    }
-
-    location / {
-      return 301 https://$host$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    server_name {{ site }};
-    error_log /var/log/nginx/{{ site }}.error.log;
-    access_log /var/log/nginx/{{ site }}.access.log;
-
-    # By default use the snakeoil certificate...
-    ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
-    ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
-
-    root /srv/{{ site }}/;
-}
-
-server {
     listen 9000 ssl;
     server_name {{ site }};
     error_log /var/log/nginx/{{ site }}.error.log;

--- a/salt/planet/init.sls
+++ b/salt/planet/init.sls
@@ -1,6 +1,5 @@
 include:
   - nginx
-  - tls.lego
 
 git:
   pkg.installed
@@ -32,30 +31,6 @@ planet-user:
     - mode: "0644"
     - require:
       - pkg: consul-pkgs
-
-lego_bootstrap:
-  cmd.run:
-    - name: /usr/local/bin/lego -a --email="infrastructure-staff@python.org" {% if pillar["dc"] == "vagrant" %}--server=https://salt-master.vagrant.psf.io:14000/dir{% endif %} --domains="{{ grains['fqdn'] }}" {%- for domain in pillar['planet']['subject_alternative_names']  %} --domains {{ domain }}{%- endfor %} --http --path /etc/lego --key-type ec256 run
-    - creates: /etc/lego/certificates/{{ grains['fqdn'] }}.json
-
-lego_renew:
-  cron.present:
-    - name: sudo -u nginx /usr/local/bin/lego -a --email="infrastructure-staff@python.org" {% if pillar["dc"] == "vagrant" %}--server=https://salt-master.vagrant.psf.io:14000/dir{% endif %} --domains="{{ grains['fqdn'] }}" {%- for domain in pillar['planet']['subject_alternative_names']  %} --domains {{ domain }}{%- endfor %} --http --http.webroot /etc/lego --path /etc/lego --key-type ec256  renew --days 30 && /usr/sbin/service nginx reload
-    - identifier: roundup_lego_renew
-    - hour: 0
-    - minute: random
-
-lego_config:
-  file.managed:
-    - name: /etc/nginx/conf.d/lego.conf
-    - source: salt://tls/config/lego.conf.jinja
-    - template: jinja
-    - user: root
-    - group: root
-    - mode: "0644"
-    - require:
-      - sls: tls.lego
-      - cmd: lego_bootstrap
 
 /srv/planet/:
   file.directory:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Finishes transfer of ssl cert handling to haproxy instead of lego

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- Closes python/planet#571

