### PR TITLE
loadbalancer: enable multiple fastly-tokens at once for key rotation

### DIFF
--- a/pillar/dev/secrets/fastly.sls
+++ b/pillar/dev/secrets/fastly.sls
@@ -1,3 +1,5 @@
 fastly:
-  token: "1"
+  tokens: |
+    1
+    2
   api_key: fakekey

--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -37,7 +37,7 @@ haproxy:
 
 /etc/haproxy/fastly_token:
   file.managed:
-    - contents_pillar: fastly:token
+    - contents_pillar: fastly:tokens
     - user: root
     - group: root
     - mode: "0640"


### PR DESCRIPTION
## Description

This allows us to have multiple concurrent fastly tokens so we can perform a rotation.