### PR TITLE
backup: accept older public key algorithms

### DIFF
--- a/salt/backup/server/init.sls
+++ b/salt/backup/server/init.sls
@@ -2,6 +2,15 @@
 include:
   - backup.base
 
+{# TODO: When we have retired distros older than 20.04, remove this #}
+/etc/ssh/ssh_config.d/pubkey.conf:
+  file.managed:
+    - contents: |
+        PubkeyAcceptedAlgorithms +ssh-rsa
+    - user: root
+    - group: root
+    - mode: "0644"
+
 {% for backup, config in salt['pillar.get']('backup-server:backups', {}).items() %}
 
 {{ backup }}-user:

--- a/salt/ssh/configs/sshd_config.jinja
+++ b/salt/ssh/configs/sshd_config.jinja
@@ -1,6 +1,11 @@
 # Basic configuration
 # ===================
 
+# Include sshd_config.d dir for distros that use it
+{% if grains["oscodename"] in ["jammy", "noble"] %}
+Include /etc/ssh/sshd_config.d/*.conf
+{% endif %}
+
 # Either disable or only allow root login via certificates.
 {% if salt["pillar.get"]("ssh:allow_root_with_key", False) %}
 PermitRootLogin without-password


### PR DESCRIPTION
## Description

mail.ams1.psf.io is using ssh-rsa still, which isn't ideal but we need to accept it in the short term until it is upgraded.

without this, backups fail with:

```
ERROR: Couldn't start up the remote connection by executing 'ssh -i /etc/backup/.ssh/id_rsa_mail-python-org -C [mail-python-org@backup.sfo1.psf.io](mailto:mail-python-org@backup.sfo1.psf.io) rdiff-backup server'
due to exception 'Truncated header <b''> (problem probably originated remotely)'.
```