### PR TITLE
Native haproxy consul integration

### DIFF
--- a/salt/consul/init.sls
+++ b/salt/consul/init.sls
@@ -7,7 +7,6 @@ consul-pkgs:
   pkg.installed:
     - pkgs:
       - consul
-      - consul-template
 
 consul:
   file.managed:
@@ -115,50 +114,6 @@ consul:
     - group: consul
     - require:
       - pkg: consul-pkgs
-
-
-consul-template:
-  pkg.installed: []
-
-  cmd.run:
-    - name: consul-template -config /etc/consul-template.d -once
-    - require:
-      - pkg: consul-pkgs
-      - service: consul
-    - onchanges:
-      - file: /etc/consul-template.d/*.json
-      - file: /usr/share/consul-template/templates/*
-
-  file.managed:
-    - name: /lib/systemd/system/consul-template.service
-    - source: salt://consul/init/consul-template.service
-    - mode: "0644"
-
-  service.running:
-    - enable: True
-    - restart: True
-    - require:
-      - pkg: consul-pkgs
-      - service: consul
-    - watch:
-      - file: consul-template
-      - file: /etc/consul-template.d/*.json
-      - file: /usr/share/consul-template/templates/*
-
-
-/etc/consul-template.d/base.json:
-  file.managed:
-    - source: salt://consul/etc/consul-template/base.json
-    - user: root
-    - group: root
-    - mode: "0644"
-
-
-/usr/share/consul-template/templates/:
-  file.directory:
-    - user: root
-    - group: consul
-
 {% endif %}
 
 

--- a/salt/haproxy/config/haproxy.cfg.jinja
+++ b/salt/haproxy/config/haproxy.cfg.jinja
@@ -1,6 +1,11 @@
 {% set haproxy = salt["pillar.get"]("haproxy", {}) -%}
 {% set psf_internal = salt["pillar.get"]("psf_internal_network") -%}
 
+resolvers consul
+    nameserver consul 127.0.0.1:8600
+    accepted_payload_size 8192
+    hold valid 5s
+
 global
     log /dev/log    local0
     log /dev/log    local1 notice
@@ -230,8 +235,7 @@ backend {{ service }}
     {{ item }}
     {% endfor -%}
 
-    {{ "{{" }}range service "{{ service }}@{{ pillar.dc }}" "any"}}
-    {% raw %}server {{.Node}} {{.Address}}:{{.Port}}{% endraw %}{% if config.get("check", True) %} check{% if config.get("sni", False)%} check-sni {{ config.get("sni") }}{% endif %}{% if config.get("sni", False)%} sni str({{ config.get("sni") }}){% endif %}{% endif %}{% if config.get("tls", True) %} ssl force-tlsv12 verifyhost {{ config.get("verify_host", service + ".psf.io") }} ca-file {{ config.get("ca-file", "PSF_CA.pem") }}{% endif %}{{ "{{end}}" }}
+    server-template backend 1-3 _{{ service }}._tcp.service.{{ pillar.dc }}.consul resolvers consul resolve-opts allow-dup-ip resolve-prefer ipv4 {% if config.get("check", True) %} check{% if config.get("sni", False)%} check-sni {{ config.get("sni") }}{% endif %}{% if config.get("sni", False)%} sni str({{ config.get("sni") }}){% endif %}{% endif %}{% if config.get("tls", True) %} ssl force-tlsv12 verifyhost {{ config.get("verify_host", service + ".psf.io") }} ca-file {{ config.get("ca-file", "PSF_CA.pem") }}{% endif %}
 
 {% endfor %}
 
@@ -248,8 +252,7 @@ listen {{ name }}
     {{ line }}
     {% endfor %}
 
-    {{ "{{" }}range service "{{ config.service }}@{{ pillar.dc }}"}}
-    {% raw %}server {{.Node}} {{.Address}}:{{.Port}} check{{end}}{% endraw %}{% if config.get("send_proxy", False) %} send-proxy{% endif %}
+    server-template backend 1-3 _{{ config.service }}._tcp.service.{{ pillar.dc }}.consul resolvers consul resolve-opts allow-dup-ip resolve-prefer ipv4 check {% if config.get("send_proxy", False) %} send-proxy{% endif %}
 
 {% endfor %}
 

--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -27,12 +27,12 @@ haproxy:
     - reload: True
     - require:
       - pkg: haproxy
-      - cmd: consul-template
       - service: rsyslog
     - watch:
       - file: /etc/ssl/private/*.pem
       - file: /etc/haproxy/fastly_token
       - file: /etc/haproxy/our_domains
+      - file: /etc/haproxy/haproxy.cfg
 
 
 /etc/haproxy/fastly_token:
@@ -56,31 +56,13 @@ haproxy:
       - pkg: haproxy
 
 
-/usr/share/consul-template/templates/haproxy.cfg:
+/etc/haproxy/haproxy.cfg:
   file.managed:
     - source: salt://haproxy/config/haproxy.cfg.jinja
     - template: jinja
     - user: root
     - group: root
     - mode: "0644"
-    - require:
-      - pkg: consul-pkgs
-
-
-/etc/consul-template.d/haproxy.json:
-  file.managed:
-    - source: salt://consul/etc/consul-template/template.json.jinja
-    - template: jinja
-    - context:
-        source: /usr/share/consul-template/templates/haproxy.cfg
-        destination: /etc/haproxy/haproxy.cfg
-        command: service haproxy reload
-    - user: root
-    - group: root
-    - mode: "0640"
-    - require:
-      - pkg: consul-pkgs
-
 
 /usr/local/bin/haproxy-ocsp:
   {% if ocsp %}


### PR DESCRIPTION
## Description

Migrates to using [consul DNS](https://developer.hashicorp.com/consul/docs/services/discovery/dns-static-lookups) via haproxy [server-template](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4.2-server-template) instead of consul-template for dynamic haproxy backends.

Drops consul-template as a dependency.