### PR TITLE
Allow Consul DNS to recurse on haproxy nodes

### DIFF
--- a/pillar/dev/consul.sls
+++ b/pillar/dev/consul.sls
@@ -17,3 +17,8 @@ consul:
       address: www.pythonanywhere.com
       service: console
       port: 443
+    - datacenter: vagrant
+      node: jobspyfound
+      address: pythonsoftwarefoundation.applytojob.com
+      service: jobs
+      port: 443

--- a/salt/haproxy/config/consul-recursors.json
+++ b/salt/haproxy/config/consul-recursors.json
@@ -1,0 +1,3 @@
+{
+    "recursors": [{% for nameserver in salt['grains.get']('dns:nameservers') %}"{{ nameserver }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+}

--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -15,6 +15,16 @@ include:
 /etc/nginx/conf.d/default.conf:
   file.absent
 
+/etc/consul.d/recursors.json:
+  file.managed:
+    - source: salt://haproxy/config/consul-recursors.json
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: "0644"
+    - require:
+      - pkg: consul-pkgs
+
 haproxy:
   pkg:
     - installed


### PR DESCRIPTION
PR #486 introduced resolution of hosts for haproxy backends via consul, but did not give it any way to resolve external DNS for the console/pythonanywhere or jobs.pyfound.org/applytojob.com backends.

This adds a recursive DNS setup on the haproxy nodes so that they can successfully and fully resolve external services.
