### PR TITLE
Update rdiff-backup command.

### DIFF
--- a/salt/backup/client/init.sls
+++ b/salt/backup/client/init.sls
@@ -39,9 +39,9 @@ include:
     - context:
         pre_script: '{{ config.get('pre_script', ":") }}'
         {% if grains["oscodename"] == "noble" -%}
-        remote_command: '/usr/bin/rdiff-backup --terminal-verbosity 1 --remote-schema "ssh -i /etc/backup/.ssh/id_rsa_{{ backup }} -C %s rdiff-backup server" backup --no-eas {%- for exclude in config.get('exclude', []) %} --exclude {{ exclude }} {%- endfor %} {{ config['source_directory'] }} {{ config['target_user'] }}@{{ config['target_host'] }}::{{ config['target_directory'] }}'
+        remote_command: '/usr/bin/rdiff-backup backup --terminal-verbosity 1 --remote-schema "ssh -i /etc/backup/.ssh/id_rsa_{{ backup }} -C %s rdiff-backup server" backup --no-eas {%- for exclude in config.get('exclude', []) %} --exclude {{ exclude }} {%- endfor %} {{ config['source_directory'] }} {{ config['target_user'] }}@{{ config['target_host'] }}::{{ config['target_directory'] }}'
         {% else %}
-        remote_command: '/usr/bin/rdiff-backup --terminal-verbosity 1 {%- for exclude in config.get('exclude', []) %} --exclude {{ exclude }} {%- endfor %} --no-eas --remote-schema "ssh -i /etc/backup/.ssh/id_rsa_{{ backup }} -C %s rdiff-backup server" {{ config['source_directory'] }} {{ config['target_user'] }}@{{ config['target_host'] }}::{{ config['target_directory'] }}'
+        remote_command: '/usr/bin/rdiff-backup backup --terminal-verbosity 1 {%- for exclude in config.get('exclude', []) %} --exclude {{ exclude }} {%- endfor %} --no-eas --remote-schema "ssh -i /etc/backup/.ssh/id_rsa_{{ backup }} -C %s rdiff-backup server" {{ config['source_directory'] }} {{ config['target_user'] }}@{{ config['target_host'] }}::{{ config['target_directory'] }}'
         {% endif %}
         post_script: '{{ config.get('post_script', ":") }}'
         cleanup_script: '{{ config.get('cleanup_script', ":") }}'


### PR DESCRIPTION
I'm seeing messages with content "WARNING: this command line interface is deprecated and will disappear, start using the new one as described with '--new --help'." from mail.python.org when cron runs /usr/local/backup/mail-python-org/scripts/backup.bash.

I'm not at all sure that this change is the appropriate fix, but I think so.

<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- 

