### PR TITLE
Update devguide redirects

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -186,6 +186,8 @@ server {
 
     # Emulate Apache's content-negotiation. Was a temporary measure,
     # but now people are using it like a feature.
+    # Redirect ``$request_uri`` -> ``$request_uri.html``,
+    # where the latter is a valid webpage.
     location ~ ^/((2|3)(\.[0-9]+)?|dev)/\w+/[\d\w\.]+(?!\.html)$ {
         if (-f "${request_filename}.html") {
             return 301 https://$host:$request_uri.html;

--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -149,28 +149,28 @@ server {
         return 301 https://devguide.python.org/$1;
     }
     location = /documenting/ {
-        return 301 https://devguide.python.org/documenting.html;
+        return 301 https://devguide.python.org/documentation/start-documenting/;
     }
     location = /documenting/index.html {
-        return 301 https://devguide.python.org/documenting.html;
+        return 301 https://devguide.python.org/documentation/start-documenting/;
     }
     location = /documenting/intro.html {
-        return 301 https://devguide.python.org/documenting.html#introduction;
+        return 301 https://devguide.python.org/documentation/start-documenting/#introduction;
     }
     location = /documenting/style.html {
-        return 301 https://devguide.python.org/documenting.html#style-guide;
+        return 301 https://devguide.python.org/documentation/style-guide/;
     }
     location = /documenting/rest.html {
-        return 301 https://devguide.python.org/documenting.html#restructuredtext-primer;
+        return 301 https://devguide.python.org/documentation/markup/;
     }
     location = /documenting/markup.html {
-        return 301 https://devguide.python.org/documenting.html#additional-markup-constructs;
+        return 301 https://devguide.python.org/documentation/markup/;
     }
     location = /documenting/fromlatex.html {
-        return 301 https://devguide.python.org/documenting.html#differences-to-the-latex-markup;
+        return 301 https://devguide.python.org/documentation/markup/;
     }
     location = /documenting/building.html {
-        return 301 https://devguide.python.org/documenting.html#building-the-documentation;
+        return 301 https://devguide.python.org/documentation/start-documenting/#building-the-documentation;
     }
 
     # Map toplevel URIs to Python 3 docs.


### PR DESCRIPTION
I was looking at the docs' NGINX config as part of seeing if #287 is feasible and noticed these redirects are out of date.

A