### PR TITLE
Redirect dead batteries

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -143,6 +143,9 @@ server {
     location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/_winreg.html$ {
         return 301 https://$host/$1$2/library/winreg.html;
     }
+    location ~ ^/([a-z-]*/)?(3|3.12|3.13|3.14)/library/(asynchat|asyncore|smtpd).html$ {
+        return 301 https://$host/$1$2/;
+    }
     location ~ ^/([a-z-]*/)?(3.13|3.14)/library/(2to3|aifc|audioop|cgi|cgitb|chunk|crypt|imghdr|mailcap|msilib|nis|nntplib|ossaudiodev|pipes|sndhdr|spwd|sunau|telnetlib|tkinter.tix|uu|xdrlib).html$ {
         return 301 https://$host/$1$2/;
     }

--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -143,6 +143,9 @@ server {
     location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/_winreg.html$ {
         return 301 https://$host/$1$2/library/winreg.html;
     }
+    location ~ ^/([a-z-]*/)?(3.13|3.14)/library/(2to3|aifc|audioop|cgi|cgitb|chunk|crypt|imghdr|mailcap|msilib|nis|nntplib|ossaudiodev|pipes|sndhdr|spwd|sunau|telnetlib|tkinter.tix|uu|xdrlib).html$ {
+        return 301 https://$host/$1$2/;
+    }
 
     # Map /documenting to the devguide.
     location ~ ^/devguide/(.*)$ {


### PR DESCRIPTION
Previous mass removals of modules have had redirects, we can do the same for PEP 594:

https://github.com/python/psf-salt/blob/20e0021e000b8ca670def1d7e9ebfdaefa64ff4a/salt/docs/config/nginx.docs-backend.conf#L53-L55

Note we can't have `3|` yet -- needs to be added post 3.13.0 release.

A