### PR TITLE
fix docs redirects include configuration

### DIFF
--- a/salt/docs/config/nginx.docs-backend.conf
+++ b/salt/docs/config/nginx.docs-backend.conf
@@ -18,7 +18,7 @@ server {
 
     # The redirect config for docs.python.org is in a separate file
     # to allow automatic testing via Hurl (https://hurl.dev/)
-    include docs-redirects.conf;
+    include sites.d/docs/redirects.conf;
 }
 
 server {

--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -122,6 +122,16 @@ docsbuild-full:
     - group: root
     - mode: "0644"
 
+/etc/nginx/sites.d/docs/redirects.conf:
+  file.managed:
+    - source: salt://docs/config/nginx.docs-redirects.conf
+    - user: root
+    - group: root
+    - mode: "0644"
+    - makedirs: True
+    - require:
+      - pkg: nginx
+
 /etc/nginx/sites.d/docs-backend.conf:
   file.managed:
     - source: salt://docs/config/nginx.docs-backend.conf
@@ -131,17 +141,7 @@ docsbuild-full:
     - require:
       - file: /etc/nginx/sites.d/
       - file: /etc/nginx/fastly_params
-      - file: /etc/nginx/conf.d/docs-redirects.conf
-
-/etc/nginx/conf.d/docs-redirects.conf:
-  file.managed:
-    - source: salt://docs/config/nginx.docs-redirects.conf
-    - user: root
-    - group: root
-    - mode: "0644"
-    - require:
-      - pkg: nginx
-
+      - file: /etc/nginx/sites.d/docs/redirects.conf
 
 /etc/consul.d/service-docs.json:
   file.managed:


### PR DESCRIPTION
## Description

Error introduced in #504, our nginx config includes conf.d/* and that caused this to choke on deploy.