### PR TITLE
ci: give write permissions to reminder

### DIFF
--- a/.github/workflows/deployminder.yml
+++ b/.github/workflows/deployminder.yml
@@ -11,6 +11,8 @@ jobs:
   remind:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+        issues: write
     steps:
       - name: Comment on PR
         uses: actions/github-script@v7


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Deployminder sometimes fails due to permissions I think
https://github.com/python/psf-salt/actions/runs/11259227771/job/31307708334?pr=510
