### PR TITLE
expose fastly purge configuration for docsbuild

### DIFF
--- a/pillar/dev/secrets/docs.sls
+++ b/pillar/dev/secrets/docs.sls
@@ -1,3 +1,6 @@
 docs:
   sentry:
     dsn: https://deadbeefdeadbeefdeadbeefdeadbeef@sentry.io/6666666
+  fastly:
+    service_id: deadbeefdeadbeefdead
+    token: deadbeefdeadbeefdeadbeefdeadbeef

--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -78,6 +78,18 @@ docsbuild-sentry:
     - name: SENTRY_DSN
     - value: {{ pillar.get('docs', {}).get('sentry', {}).get('dsn', '') }}
 
+docsbuild-fastly-service-id:
+  cron.env_present:
+    - user: docsbuild
+    - name: FASTLY_SERVICE_ID
+    - value: {{ pillar.get('docs', {}).get('fastly', {}).get('service_id', '') }}
+
+docsbuild-fastly-token:
+  cron.env_present:
+    - user: docsbuild
+    - name: FASTLY_TOKEN
+    - value: {{ pillar.get('docs', {}).get('fastly', {}).get('token', '') }}
+
 docsbuild-no-html:
   cron.present:
     - identifier: docsbuild-no-html


### PR DESCRIPTION
## Description

Towards #287. #510 implements Surrogate-Keys for docs responses, this will allow for the docsbuild scripts to issue purges against the API when they are updated.