### PR TITLE
Add an English-only docsbuild scheduled job

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -81,6 +81,7 @@ docsbuild-sentry:
 
 docsbuild-no-html:
   cron.present:
+    # run every other day at 07:06
     - identifier: docsbuild-no-html
     - name: >
         /srv/docsbuild/venv/bin/python
@@ -89,18 +90,35 @@ docsbuild-no-html:
     - user: docsbuild
     - minute: 7
     - hour: 6
+    - daymonth: '*/2'
     - require:
       - cmd: virtualenv-dependencies
 
 docsbuild-only-html:
   cron.present:
+    # run daily at 04:42
     - identifier: docsbuild-only-html
     - name: >
         /srv/docsbuild/venv/bin/python
         /srv/docsbuild/scripts/build_docs.py
         --select-output=only-html
     - user: docsbuild
-    - minute: 16
+    - minute: 42
+    - hour: 4
+    - require:
+      - cmd: virtualenv-dependencies
+
+docsbuild-only-html-en:
+  cron.present:
+    # run twice hourly at HH:16 and HH:46
+    - identifier: docsbuild-only-html
+    - name: >
+        /srv/docsbuild/venv/bin/python
+        /srv/docsbuild/scripts/build_docs.py
+        --select-output=only-html-en
+        --language=en
+    - user: docsbuild
+    - minute: 16,46
     - require:
       - cmd: virtualenv-dependencies
 


### PR DESCRIPTION
The English docs are more popular by an order of magnitude per the [plausible statistics](https://plausible.io/docs.python.org/pages).

We increase rebuild of English-only to twice per hour, decrease other languages to daily, and decrease the non-HTML archives builds to every other day.

A
