### PR TITLE
Fix indentifier

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -111,7 +111,7 @@ docsbuild-only-html:
 docsbuild-only-html-en:
   cron.present:
     # run twice hourly at HH:16 and HH:46
-    - identifier: docsbuild-only-html
+    - identifier: docsbuild-only-html-en
     - name: >
         /srv/docsbuild/venv/bin/python
         /srv/docsbuild/scripts/build_docs.py


### PR DESCRIPTION
cc @JacobCoffee 

I forgot to make the identifier distinct, which means crontab is now inconsistent:

```bash
$ sudo crontab -l -u docsbuild
[...snip...]
# SALT_CRON_IDENTIFIER:docsbuild-no-html
7 6 */2 * * /srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --select-output=no-html
# SALT_CRON_IDENTIFIER:docsbuild-only-html
16,46 * * * * /srv/docsbuild/venv/bin/python /srv/docsbuild/scripts/build_docs.py --select-output=only-html-en --language=en
```

A