### PR TITLE
Avoid multiple redirects in pre-2.5 paths

### DIFF
--- a/salt/docs/config/nginx.docs-redirects.conf
+++ b/salt/docs/config/nginx.docs-redirects.conf
@@ -199,32 +199,32 @@ location ~ ^/(es|fr|id|it|ja|ko|pl|pt-br|tr|uk|zh-cn|zh-tw)/((2|3)(\.[0-9]+)?|de
 
 # Map old, 2.5-and-earlier directory names to 2.6-and-later names.
 location = /lib/ {
-    return 301 https://$host/library/;
+    return 301 https://$host/3/library/;
 }
 location ~ ^/lib/module-([a-zA-Z0-9.]+)\.html$ {
-    return 301 https://$host/library/$1.html;
+    return 301 https://$host/3/library/$1.html;
 }
 location = /tut/ {
-    return 301 https://$host/tutorial/;
+    return 301 https://$host/3/tutorial/;
 }
 location = /tut/tut.html {
-    return 301 https://$host/tutorial/;
+    return 301 https://$host/3/tutorial/;
 }
 location = /api/ {
-    return 301 https://$host/c-api/;
+    return 301 https://$host/3/c-api/;
 }
 location = /ext/ {
-    return 301 https://$host/extending/;
+    return 301 https://$host/3/extending/;
 }
 location = /dist/ {
-    return 301 https://docs.python.org/distutils/;
+    return 301 https://$host/3/;
 }
 location = /inst/ {
-    return 301 https://$host/install/;
+    return 301 https://$host/3/;
 }
 location = /doc/ {
-    return 301 https://devguide.python.org/documenting.html;
+    return 301 https://devguide.python.org/documentation/start-documenting/;
 }
 location = /ref/ {
-    return 301 https://$host/reference/;
+    return 301 https://$host/3/reference/;
 }

--- a/tests/docs-redirects/specs/py2.5.hurl
+++ b/tests/docs-redirects/specs/py2.5.hurl
@@ -4,54 +4,54 @@
 GET {{host}}/lib/
 HTTP 301
 [Asserts]
-header "Location" == "https://localhost/library/"
+header "Location" == "https://localhost/3/library/"
 
 GET {{host}}/lib/module-base64.html
 HTTP 301
 [Asserts]
-header "Location" == "https://localhost/library/base64.html"
+header "Location" == "https://localhost/3/library/base64.html"
 
 GET {{host}}/lib/module-sys.html
 HTTP 301
 [Asserts]
-header "Location" == "https://localhost/library/sys.html"
+header "Location" == "https://localhost/3/library/sys.html"
 
 GET {{host}}/tut/
 HTTP 301
 [Asserts]
-header "Location" == "https://localhost/tutorial/"
+header "Location" == "https://localhost/3/tutorial/"
 
 GET {{host}}/tut/tut.html
 HTTP 301
 [Asserts]
-header "Location" == "https://localhost/tutorial/"
+header "Location" == "https://localhost/3/tutorial/"
 
 GET {{host}}/api/
 HTTP 301
 [Asserts]
-header "Location" == "https://localhost/c-api/"
+header "Location" == "https://localhost/3/c-api/"
 
 GET {{host}}/ext/
 HTTP 301
 [Asserts]
-header "Location" == "https://localhost/extending/"
+header "Location" == "https://localhost/3/extending/"
 
 GET {{host}}/dist/
 HTTP 301
 [Asserts]
-header "Location" == "https://docs.python.org/distutils/"
+header "Location" == "https://localhost/3/"
 
 GET {{host}}/inst/
 HTTP 301
 [Asserts]
-header "Location" == "https://localhost/install/"
+header "Location" == "https://localhost/3/"
 
 GET {{host}}/doc/
 HTTP 301
 [Asserts]
-header "Location" == "https://devguide.python.org/documenting.html"
+header "Location" == "https://devguide.python.org/documentation/start-documenting/"
 
 GET {{host}}/ref/
 HTTP 301
 [Asserts]
-header "Location" == "https://localhost/reference/"
+header "Location" == "https://localhost/3/reference/"


### PR DESCRIPTION
This flattens multiple redirects in the Python 2.5 redirects.

We also remove redirects for `/dist/` and `/inst/` as `/distutils` and `/install` have been removed as pages on the website.

A