### PR TITLE
Redirect PEP 594 dead batteries (part 2)

### DIFF
--- a/salt/docs/config/nginx.docs-redirects.conf
+++ b/salt/docs/config/nginx.docs-redirects.conf
@@ -133,7 +133,7 @@ location ~ ^/([a-z-]*/)?(3|3.5|3.6|3.7|3.8|3.9|3.10)/library/_winreg.html$ {
 location ~ ^/([a-z-]*/)?(3|3.12|3.13|3.14)/library/(asynchat|asyncore|smtpd).html$ {
     return 301 https://$host/$1$2/;
 }
-location ~ ^/([a-z-]*/)?(3.13|3.14)/library/(2to3|aifc|audioop|cgi|cgitb|chunk|crypt|imghdr|mailcap|msilib|nis|nntplib|ossaudiodev|pipes|sndhdr|spwd|sunau|telnetlib|tkinter.tix|uu|xdrlib).html$ {
+location ~ ^/([a-z-]*/)?(3|3.13|3.14)/library/(2to3|aifc|audioop|cgi|cgitb|chunk|crypt|imghdr|mailcap|msilib|nis|nntplib|ossaudiodev|pipes|sndhdr|spwd|sunau|telnetlib|tkinter.tix|uu|xdrlib).html$ {
     return 301 https://$host/$1$2/;
 }
 

--- a/tests/docs-redirects/specs/PEP-594.hurl
+++ b/tests/docs-redirects/specs/PEP-594.hurl
@@ -3,6 +3,11 @@
 
 
 ## Test: Redirect library/2to3.html -> ''
+GET {{host}}/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/2to3.html
 HTTP 301
 [Asserts]
@@ -12,6 +17,11 @@ GET {{host}}/3.14/library/2to3.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/2to3.html
 HTTP 301
@@ -23,6 +33,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/2to3.html
 HTTP 301
 [Asserts]
@@ -32,6 +47,11 @@ GET {{host}}/fr/3.14/library/2to3.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/2to3.html
 HTTP 301
@@ -43,6 +63,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/2to3.html
 HTTP 301
 [Asserts]
@@ -52,6 +77,11 @@ GET {{host}}/it/3.14/library/2to3.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/2to3.html
 HTTP 301
@@ -63,6 +93,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/2to3.html
 HTTP 301
 [Asserts]
@@ -72,6 +107,11 @@ GET {{host}}/ko/3.14/library/2to3.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/2to3.html
 HTTP 301
@@ -83,6 +123,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/2to3.html
 HTTP 301
 [Asserts]
@@ -92,6 +137,11 @@ GET {{host}}/pt-br/3.14/library/2to3.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/2to3.html
 HTTP 301
@@ -103,6 +153,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/2to3.html
 HTTP 301
 [Asserts]
@@ -113,6 +168,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/2to3.html
 HTTP 301
 [Asserts]
@@ -122,6 +182,11 @@ GET {{host}}/zh-cn/3.14/library/2to3.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/2to3.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/2to3.html
 HTTP 301
@@ -135,6 +200,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/aifc.html -> ''
+GET {{host}}/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/aifc.html
 HTTP 301
 [Asserts]
@@ -144,6 +214,11 @@ GET {{host}}/3.14/library/aifc.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/aifc.html
 HTTP 301
@@ -155,6 +230,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/aifc.html
 HTTP 301
 [Asserts]
@@ -164,6 +244,11 @@ GET {{host}}/fr/3.14/library/aifc.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/aifc.html
 HTTP 301
@@ -175,6 +260,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/aifc.html
 HTTP 301
 [Asserts]
@@ -184,6 +274,11 @@ GET {{host}}/it/3.14/library/aifc.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/aifc.html
 HTTP 301
@@ -195,6 +290,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/aifc.html
 HTTP 301
 [Asserts]
@@ -204,6 +304,11 @@ GET {{host}}/ko/3.14/library/aifc.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/aifc.html
 HTTP 301
@@ -215,6 +320,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/aifc.html
 HTTP 301
 [Asserts]
@@ -224,6 +334,11 @@ GET {{host}}/pt-br/3.14/library/aifc.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/aifc.html
 HTTP 301
@@ -235,6 +350,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/aifc.html
 HTTP 301
 [Asserts]
@@ -245,6 +365,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/aifc.html
 HTTP 301
 [Asserts]
@@ -254,6 +379,11 @@ GET {{host}}/zh-cn/3.14/library/aifc.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/aifc.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/aifc.html
 HTTP 301
@@ -267,6 +397,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/audioop.html -> ''
+GET {{host}}/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/audioop.html
 HTTP 301
 [Asserts]
@@ -276,6 +411,11 @@ GET {{host}}/3.14/library/audioop.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/audioop.html
 HTTP 301
@@ -287,6 +427,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/audioop.html
 HTTP 301
 [Asserts]
@@ -296,6 +441,11 @@ GET {{host}}/fr/3.14/library/audioop.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/audioop.html
 HTTP 301
@@ -307,6 +457,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/audioop.html
 HTTP 301
 [Asserts]
@@ -316,6 +471,11 @@ GET {{host}}/it/3.14/library/audioop.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/audioop.html
 HTTP 301
@@ -327,6 +487,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/audioop.html
 HTTP 301
 [Asserts]
@@ -336,6 +501,11 @@ GET {{host}}/ko/3.14/library/audioop.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/audioop.html
 HTTP 301
@@ -347,6 +517,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/audioop.html
 HTTP 301
 [Asserts]
@@ -356,6 +531,11 @@ GET {{host}}/pt-br/3.14/library/audioop.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/audioop.html
 HTTP 301
@@ -367,6 +547,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/audioop.html
 HTTP 301
 [Asserts]
@@ -377,6 +562,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/audioop.html
 HTTP 301
 [Asserts]
@@ -386,6 +576,11 @@ GET {{host}}/zh-cn/3.14/library/audioop.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/audioop.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/audioop.html
 HTTP 301
@@ -399,6 +594,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/cgi.html -> ''
+GET {{host}}/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/cgi.html
 HTTP 301
 [Asserts]
@@ -408,6 +608,11 @@ GET {{host}}/3.14/library/cgi.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/cgi.html
 HTTP 301
@@ -419,6 +624,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/cgi.html
 HTTP 301
 [Asserts]
@@ -428,6 +638,11 @@ GET {{host}}/fr/3.14/library/cgi.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/cgi.html
 HTTP 301
@@ -439,6 +654,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/cgi.html
 HTTP 301
 [Asserts]
@@ -448,6 +668,11 @@ GET {{host}}/it/3.14/library/cgi.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/cgi.html
 HTTP 301
@@ -459,6 +684,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/cgi.html
 HTTP 301
 [Asserts]
@@ -468,6 +698,11 @@ GET {{host}}/ko/3.14/library/cgi.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/cgi.html
 HTTP 301
@@ -479,6 +714,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/cgi.html
 HTTP 301
 [Asserts]
@@ -488,6 +728,11 @@ GET {{host}}/pt-br/3.14/library/cgi.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/cgi.html
 HTTP 301
@@ -499,6 +744,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/cgi.html
 HTTP 301
 [Asserts]
@@ -509,6 +759,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/cgi.html
 HTTP 301
 [Asserts]
@@ -518,6 +773,11 @@ GET {{host}}/zh-cn/3.14/library/cgi.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/cgi.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/cgi.html
 HTTP 301
@@ -531,6 +791,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/cgitb.html -> ''
+GET {{host}}/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/cgitb.html
 HTTP 301
 [Asserts]
@@ -540,6 +805,11 @@ GET {{host}}/3.14/library/cgitb.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/cgitb.html
 HTTP 301
@@ -551,6 +821,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/cgitb.html
 HTTP 301
 [Asserts]
@@ -560,6 +835,11 @@ GET {{host}}/fr/3.14/library/cgitb.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/cgitb.html
 HTTP 301
@@ -571,6 +851,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/cgitb.html
 HTTP 301
 [Asserts]
@@ -580,6 +865,11 @@ GET {{host}}/it/3.14/library/cgitb.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/cgitb.html
 HTTP 301
@@ -591,6 +881,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/cgitb.html
 HTTP 301
 [Asserts]
@@ -600,6 +895,11 @@ GET {{host}}/ko/3.14/library/cgitb.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/cgitb.html
 HTTP 301
@@ -611,6 +911,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/cgitb.html
 HTTP 301
 [Asserts]
@@ -620,6 +925,11 @@ GET {{host}}/pt-br/3.14/library/cgitb.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/cgitb.html
 HTTP 301
@@ -631,6 +941,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/cgitb.html
 HTTP 301
 [Asserts]
@@ -641,6 +956,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/cgitb.html
 HTTP 301
 [Asserts]
@@ -650,6 +970,11 @@ GET {{host}}/zh-cn/3.14/library/cgitb.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/cgitb.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/cgitb.html
 HTTP 301
@@ -663,6 +988,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/chunk.html -> ''
+GET {{host}}/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/chunk.html
 HTTP 301
 [Asserts]
@@ -672,6 +1002,11 @@ GET {{host}}/3.14/library/chunk.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/chunk.html
 HTTP 301
@@ -683,6 +1018,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/chunk.html
 HTTP 301
 [Asserts]
@@ -692,6 +1032,11 @@ GET {{host}}/fr/3.14/library/chunk.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/chunk.html
 HTTP 301
@@ -703,6 +1048,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/chunk.html
 HTTP 301
 [Asserts]
@@ -712,6 +1062,11 @@ GET {{host}}/it/3.14/library/chunk.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/chunk.html
 HTTP 301
@@ -723,6 +1078,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/chunk.html
 HTTP 301
 [Asserts]
@@ -732,6 +1092,11 @@ GET {{host}}/ko/3.14/library/chunk.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/chunk.html
 HTTP 301
@@ -743,6 +1108,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/chunk.html
 HTTP 301
 [Asserts]
@@ -752,6 +1122,11 @@ GET {{host}}/pt-br/3.14/library/chunk.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/chunk.html
 HTTP 301
@@ -763,6 +1138,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/chunk.html
 HTTP 301
 [Asserts]
@@ -773,6 +1153,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/chunk.html
 HTTP 301
 [Asserts]
@@ -782,6 +1167,11 @@ GET {{host}}/zh-cn/3.14/library/chunk.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/chunk.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/chunk.html
 HTTP 301
@@ -795,6 +1185,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/crypt.html -> ''
+GET {{host}}/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/crypt.html
 HTTP 301
 [Asserts]
@@ -804,6 +1199,11 @@ GET {{host}}/3.14/library/crypt.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/crypt.html
 HTTP 301
@@ -815,6 +1215,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/crypt.html
 HTTP 301
 [Asserts]
@@ -824,6 +1229,11 @@ GET {{host}}/fr/3.14/library/crypt.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/crypt.html
 HTTP 301
@@ -835,6 +1245,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/crypt.html
 HTTP 301
 [Asserts]
@@ -844,6 +1259,11 @@ GET {{host}}/it/3.14/library/crypt.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/crypt.html
 HTTP 301
@@ -855,6 +1275,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/crypt.html
 HTTP 301
 [Asserts]
@@ -864,6 +1289,11 @@ GET {{host}}/ko/3.14/library/crypt.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/crypt.html
 HTTP 301
@@ -875,6 +1305,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/crypt.html
 HTTP 301
 [Asserts]
@@ -884,6 +1319,11 @@ GET {{host}}/pt-br/3.14/library/crypt.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/crypt.html
 HTTP 301
@@ -895,6 +1335,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/crypt.html
 HTTP 301
 [Asserts]
@@ -905,6 +1350,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/crypt.html
 HTTP 301
 [Asserts]
@@ -914,6 +1364,11 @@ GET {{host}}/zh-cn/3.14/library/crypt.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/crypt.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/crypt.html
 HTTP 301
@@ -927,6 +1382,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/imghdr.html -> ''
+GET {{host}}/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/imghdr.html
 HTTP 301
 [Asserts]
@@ -936,6 +1396,11 @@ GET {{host}}/3.14/library/imghdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/imghdr.html
 HTTP 301
@@ -947,6 +1412,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/imghdr.html
 HTTP 301
 [Asserts]
@@ -956,6 +1426,11 @@ GET {{host}}/fr/3.14/library/imghdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/imghdr.html
 HTTP 301
@@ -967,6 +1442,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/imghdr.html
 HTTP 301
 [Asserts]
@@ -976,6 +1456,11 @@ GET {{host}}/it/3.14/library/imghdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/imghdr.html
 HTTP 301
@@ -987,6 +1472,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/imghdr.html
 HTTP 301
 [Asserts]
@@ -996,6 +1486,11 @@ GET {{host}}/ko/3.14/library/imghdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/imghdr.html
 HTTP 301
@@ -1007,6 +1502,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/imghdr.html
 HTTP 301
 [Asserts]
@@ -1016,6 +1516,11 @@ GET {{host}}/pt-br/3.14/library/imghdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/imghdr.html
 HTTP 301
@@ -1027,6 +1532,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/imghdr.html
 HTTP 301
 [Asserts]
@@ -1037,6 +1547,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/imghdr.html
 HTTP 301
 [Asserts]
@@ -1046,6 +1561,11 @@ GET {{host}}/zh-cn/3.14/library/imghdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/imghdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/imghdr.html
 HTTP 301
@@ -1059,6 +1579,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/mailcap.html -> ''
+GET {{host}}/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/mailcap.html
 HTTP 301
 [Asserts]
@@ -1068,6 +1593,11 @@ GET {{host}}/3.14/library/mailcap.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/mailcap.html
 HTTP 301
@@ -1079,6 +1609,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/mailcap.html
 HTTP 301
 [Asserts]
@@ -1088,6 +1623,11 @@ GET {{host}}/fr/3.14/library/mailcap.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/mailcap.html
 HTTP 301
@@ -1099,6 +1639,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/mailcap.html
 HTTP 301
 [Asserts]
@@ -1108,6 +1653,11 @@ GET {{host}}/it/3.14/library/mailcap.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/mailcap.html
 HTTP 301
@@ -1119,6 +1669,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/mailcap.html
 HTTP 301
 [Asserts]
@@ -1128,6 +1683,11 @@ GET {{host}}/ko/3.14/library/mailcap.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/mailcap.html
 HTTP 301
@@ -1139,6 +1699,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/mailcap.html
 HTTP 301
 [Asserts]
@@ -1148,6 +1713,11 @@ GET {{host}}/pt-br/3.14/library/mailcap.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/mailcap.html
 HTTP 301
@@ -1159,6 +1729,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/mailcap.html
 HTTP 301
 [Asserts]
@@ -1169,6 +1744,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/mailcap.html
 HTTP 301
 [Asserts]
@@ -1178,6 +1758,11 @@ GET {{host}}/zh-cn/3.14/library/mailcap.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/mailcap.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/mailcap.html
 HTTP 301
@@ -1191,6 +1776,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/msilib.html -> ''
+GET {{host}}/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/msilib.html
 HTTP 301
 [Asserts]
@@ -1200,6 +1790,11 @@ GET {{host}}/3.14/library/msilib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/msilib.html
 HTTP 301
@@ -1211,6 +1806,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/msilib.html
 HTTP 301
 [Asserts]
@@ -1220,6 +1820,11 @@ GET {{host}}/fr/3.14/library/msilib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/msilib.html
 HTTP 301
@@ -1231,6 +1836,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/msilib.html
 HTTP 301
 [Asserts]
@@ -1240,6 +1850,11 @@ GET {{host}}/it/3.14/library/msilib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/msilib.html
 HTTP 301
@@ -1251,6 +1866,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/msilib.html
 HTTP 301
 [Asserts]
@@ -1260,6 +1880,11 @@ GET {{host}}/ko/3.14/library/msilib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/msilib.html
 HTTP 301
@@ -1271,6 +1896,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/msilib.html
 HTTP 301
 [Asserts]
@@ -1280,6 +1910,11 @@ GET {{host}}/pt-br/3.14/library/msilib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/msilib.html
 HTTP 301
@@ -1291,6 +1926,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/msilib.html
 HTTP 301
 [Asserts]
@@ -1301,6 +1941,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/msilib.html
 HTTP 301
 [Asserts]
@@ -1310,6 +1955,11 @@ GET {{host}}/zh-cn/3.14/library/msilib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/msilib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/msilib.html
 HTTP 301
@@ -1323,6 +1973,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/nis.html -> ''
+GET {{host}}/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/nis.html
 HTTP 301
 [Asserts]
@@ -1332,6 +1987,11 @@ GET {{host}}/3.14/library/nis.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/nis.html
 HTTP 301
@@ -1343,6 +2003,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/nis.html
 HTTP 301
 [Asserts]
@@ -1352,6 +2017,11 @@ GET {{host}}/fr/3.14/library/nis.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/nis.html
 HTTP 301
@@ -1363,6 +2033,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/nis.html
 HTTP 301
 [Asserts]
@@ -1372,6 +2047,11 @@ GET {{host}}/it/3.14/library/nis.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/nis.html
 HTTP 301
@@ -1383,6 +2063,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/nis.html
 HTTP 301
 [Asserts]
@@ -1392,6 +2077,11 @@ GET {{host}}/ko/3.14/library/nis.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/nis.html
 HTTP 301
@@ -1403,6 +2093,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/nis.html
 HTTP 301
 [Asserts]
@@ -1412,6 +2107,11 @@ GET {{host}}/pt-br/3.14/library/nis.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/nis.html
 HTTP 301
@@ -1423,6 +2123,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/nis.html
 HTTP 301
 [Asserts]
@@ -1433,6 +2138,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/nis.html
 HTTP 301
 [Asserts]
@@ -1442,6 +2152,11 @@ GET {{host}}/zh-cn/3.14/library/nis.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/nis.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/nis.html
 HTTP 301
@@ -1455,6 +2170,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/nntplib.html -> ''
+GET {{host}}/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/nntplib.html
 HTTP 301
 [Asserts]
@@ -1464,6 +2184,11 @@ GET {{host}}/3.14/library/nntplib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/nntplib.html
 HTTP 301
@@ -1475,6 +2200,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/nntplib.html
 HTTP 301
 [Asserts]
@@ -1484,6 +2214,11 @@ GET {{host}}/fr/3.14/library/nntplib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/nntplib.html
 HTTP 301
@@ -1495,6 +2230,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/nntplib.html
 HTTP 301
 [Asserts]
@@ -1504,6 +2244,11 @@ GET {{host}}/it/3.14/library/nntplib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/nntplib.html
 HTTP 301
@@ -1515,6 +2260,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/nntplib.html
 HTTP 301
 [Asserts]
@@ -1524,6 +2274,11 @@ GET {{host}}/ko/3.14/library/nntplib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/nntplib.html
 HTTP 301
@@ -1535,6 +2290,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/nntplib.html
 HTTP 301
 [Asserts]
@@ -1544,6 +2304,11 @@ GET {{host}}/pt-br/3.14/library/nntplib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/nntplib.html
 HTTP 301
@@ -1555,6 +2320,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/nntplib.html
 HTTP 301
 [Asserts]
@@ -1565,6 +2335,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/nntplib.html
 HTTP 301
 [Asserts]
@@ -1574,6 +2349,11 @@ GET {{host}}/zh-cn/3.14/library/nntplib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/nntplib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/nntplib.html
 HTTP 301
@@ -1587,6 +2367,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/ossaudiodev.html -> ''
+GET {{host}}/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/ossaudiodev.html
 HTTP 301
 [Asserts]
@@ -1596,6 +2381,11 @@ GET {{host}}/3.14/library/ossaudiodev.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/ossaudiodev.html
 HTTP 301
@@ -1607,6 +2397,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/ossaudiodev.html
 HTTP 301
 [Asserts]
@@ -1616,6 +2411,11 @@ GET {{host}}/fr/3.14/library/ossaudiodev.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/ossaudiodev.html
 HTTP 301
@@ -1627,6 +2427,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/ossaudiodev.html
 HTTP 301
 [Asserts]
@@ -1636,6 +2441,11 @@ GET {{host}}/it/3.14/library/ossaudiodev.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/ossaudiodev.html
 HTTP 301
@@ -1647,6 +2457,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/ossaudiodev.html
 HTTP 301
 [Asserts]
@@ -1656,6 +2471,11 @@ GET {{host}}/ko/3.14/library/ossaudiodev.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/ossaudiodev.html
 HTTP 301
@@ -1667,6 +2487,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/ossaudiodev.html
 HTTP 301
 [Asserts]
@@ -1676,6 +2501,11 @@ GET {{host}}/pt-br/3.14/library/ossaudiodev.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/ossaudiodev.html
 HTTP 301
@@ -1687,6 +2517,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/ossaudiodev.html
 HTTP 301
 [Asserts]
@@ -1697,6 +2532,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/ossaudiodev.html
 HTTP 301
 [Asserts]
@@ -1706,6 +2546,11 @@ GET {{host}}/zh-cn/3.14/library/ossaudiodev.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/ossaudiodev.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/ossaudiodev.html
 HTTP 301
@@ -1719,6 +2564,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/pipes.html -> ''
+GET {{host}}/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/pipes.html
 HTTP 301
 [Asserts]
@@ -1728,6 +2578,11 @@ GET {{host}}/3.14/library/pipes.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/pipes.html
 HTTP 301
@@ -1739,6 +2594,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/pipes.html
 HTTP 301
 [Asserts]
@@ -1748,6 +2608,11 @@ GET {{host}}/fr/3.14/library/pipes.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/pipes.html
 HTTP 301
@@ -1759,6 +2624,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/pipes.html
 HTTP 301
 [Asserts]
@@ -1768,6 +2638,11 @@ GET {{host}}/it/3.14/library/pipes.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/pipes.html
 HTTP 301
@@ -1779,6 +2654,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/pipes.html
 HTTP 301
 [Asserts]
@@ -1788,6 +2668,11 @@ GET {{host}}/ko/3.14/library/pipes.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/pipes.html
 HTTP 301
@@ -1799,6 +2684,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/pipes.html
 HTTP 301
 [Asserts]
@@ -1808,6 +2698,11 @@ GET {{host}}/pt-br/3.14/library/pipes.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/pipes.html
 HTTP 301
@@ -1819,6 +2714,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/pipes.html
 HTTP 301
 [Asserts]
@@ -1829,6 +2729,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/pipes.html
 HTTP 301
 [Asserts]
@@ -1838,6 +2743,11 @@ GET {{host}}/zh-cn/3.14/library/pipes.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/pipes.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/pipes.html
 HTTP 301
@@ -1851,6 +2761,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/sndhdr.html -> ''
+GET {{host}}/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/sndhdr.html
 HTTP 301
 [Asserts]
@@ -1860,6 +2775,11 @@ GET {{host}}/3.14/library/sndhdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/sndhdr.html
 HTTP 301
@@ -1871,6 +2791,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/sndhdr.html
 HTTP 301
 [Asserts]
@@ -1880,6 +2805,11 @@ GET {{host}}/fr/3.14/library/sndhdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/sndhdr.html
 HTTP 301
@@ -1891,6 +2821,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/sndhdr.html
 HTTP 301
 [Asserts]
@@ -1900,6 +2835,11 @@ GET {{host}}/it/3.14/library/sndhdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/sndhdr.html
 HTTP 301
@@ -1911,6 +2851,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/sndhdr.html
 HTTP 301
 [Asserts]
@@ -1920,6 +2865,11 @@ GET {{host}}/ko/3.14/library/sndhdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/sndhdr.html
 HTTP 301
@@ -1931,6 +2881,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/sndhdr.html
 HTTP 301
 [Asserts]
@@ -1940,6 +2895,11 @@ GET {{host}}/pt-br/3.14/library/sndhdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/sndhdr.html
 HTTP 301
@@ -1951,6 +2911,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/sndhdr.html
 HTTP 301
 [Asserts]
@@ -1961,6 +2926,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/sndhdr.html
 HTTP 301
 [Asserts]
@@ -1970,6 +2940,11 @@ GET {{host}}/zh-cn/3.14/library/sndhdr.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/sndhdr.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/sndhdr.html
 HTTP 301
@@ -1983,6 +2958,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/spwd.html -> ''
+GET {{host}}/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/spwd.html
 HTTP 301
 [Asserts]
@@ -1992,6 +2972,11 @@ GET {{host}}/3.14/library/spwd.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/spwd.html
 HTTP 301
@@ -2003,6 +2988,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/spwd.html
 HTTP 301
 [Asserts]
@@ -2012,6 +3002,11 @@ GET {{host}}/fr/3.14/library/spwd.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/spwd.html
 HTTP 301
@@ -2023,6 +3018,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/spwd.html
 HTTP 301
 [Asserts]
@@ -2032,6 +3032,11 @@ GET {{host}}/it/3.14/library/spwd.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/spwd.html
 HTTP 301
@@ -2043,6 +3048,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/spwd.html
 HTTP 301
 [Asserts]
@@ -2052,6 +3062,11 @@ GET {{host}}/ko/3.14/library/spwd.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/spwd.html
 HTTP 301
@@ -2063,6 +3078,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/spwd.html
 HTTP 301
 [Asserts]
@@ -2072,6 +3092,11 @@ GET {{host}}/pt-br/3.14/library/spwd.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/spwd.html
 HTTP 301
@@ -2083,6 +3108,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/spwd.html
 HTTP 301
 [Asserts]
@@ -2093,6 +3123,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/spwd.html
 HTTP 301
 [Asserts]
@@ -2102,6 +3137,11 @@ GET {{host}}/zh-cn/3.14/library/spwd.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/spwd.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/spwd.html
 HTTP 301
@@ -2115,6 +3155,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/sunau.html -> ''
+GET {{host}}/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/sunau.html
 HTTP 301
 [Asserts]
@@ -2124,6 +3169,11 @@ GET {{host}}/3.14/library/sunau.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/sunau.html
 HTTP 301
@@ -2135,6 +3185,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/sunau.html
 HTTP 301
 [Asserts]
@@ -2144,6 +3199,11 @@ GET {{host}}/fr/3.14/library/sunau.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/sunau.html
 HTTP 301
@@ -2155,6 +3215,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/sunau.html
 HTTP 301
 [Asserts]
@@ -2164,6 +3229,11 @@ GET {{host}}/it/3.14/library/sunau.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/sunau.html
 HTTP 301
@@ -2175,6 +3245,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/sunau.html
 HTTP 301
 [Asserts]
@@ -2184,6 +3259,11 @@ GET {{host}}/ko/3.14/library/sunau.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/sunau.html
 HTTP 301
@@ -2195,6 +3275,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/sunau.html
 HTTP 301
 [Asserts]
@@ -2204,6 +3289,11 @@ GET {{host}}/pt-br/3.14/library/sunau.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/sunau.html
 HTTP 301
@@ -2215,6 +3305,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/sunau.html
 HTTP 301
 [Asserts]
@@ -2225,6 +3320,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/sunau.html
 HTTP 301
 [Asserts]
@@ -2234,6 +3334,11 @@ GET {{host}}/zh-cn/3.14/library/sunau.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/sunau.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/sunau.html
 HTTP 301
@@ -2247,6 +3352,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/telnetlib.html -> ''
+GET {{host}}/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/telnetlib.html
 HTTP 301
 [Asserts]
@@ -2256,6 +3366,11 @@ GET {{host}}/3.14/library/telnetlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/telnetlib.html
 HTTP 301
@@ -2267,6 +3382,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/telnetlib.html
 HTTP 301
 [Asserts]
@@ -2276,6 +3396,11 @@ GET {{host}}/fr/3.14/library/telnetlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/telnetlib.html
 HTTP 301
@@ -2287,6 +3412,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/telnetlib.html
 HTTP 301
 [Asserts]
@@ -2296,6 +3426,11 @@ GET {{host}}/it/3.14/library/telnetlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/telnetlib.html
 HTTP 301
@@ -2307,6 +3442,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/telnetlib.html
 HTTP 301
 [Asserts]
@@ -2316,6 +3456,11 @@ GET {{host}}/ko/3.14/library/telnetlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/telnetlib.html
 HTTP 301
@@ -2327,6 +3472,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/telnetlib.html
 HTTP 301
 [Asserts]
@@ -2336,6 +3486,11 @@ GET {{host}}/pt-br/3.14/library/telnetlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/telnetlib.html
 HTTP 301
@@ -2347,6 +3502,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/telnetlib.html
 HTTP 301
 [Asserts]
@@ -2357,6 +3517,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/telnetlib.html
 HTTP 301
 [Asserts]
@@ -2366,6 +3531,11 @@ GET {{host}}/zh-cn/3.14/library/telnetlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/telnetlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/telnetlib.html
 HTTP 301
@@ -2379,6 +3549,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/tkinter.tix.html -> ''
+GET {{host}}/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/tkinter.tix.html
 HTTP 301
 [Asserts]
@@ -2388,6 +3563,11 @@ GET {{host}}/3.14/library/tkinter.tix.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/tkinter.tix.html
 HTTP 301
@@ -2399,6 +3579,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/tkinter.tix.html
 HTTP 301
 [Asserts]
@@ -2408,6 +3593,11 @@ GET {{host}}/fr/3.14/library/tkinter.tix.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/tkinter.tix.html
 HTTP 301
@@ -2419,6 +3609,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/tkinter.tix.html
 HTTP 301
 [Asserts]
@@ -2428,6 +3623,11 @@ GET {{host}}/it/3.14/library/tkinter.tix.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/tkinter.tix.html
 HTTP 301
@@ -2439,6 +3639,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/tkinter.tix.html
 HTTP 301
 [Asserts]
@@ -2448,6 +3653,11 @@ GET {{host}}/ko/3.14/library/tkinter.tix.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/tkinter.tix.html
 HTTP 301
@@ -2459,6 +3669,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/tkinter.tix.html
 HTTP 301
 [Asserts]
@@ -2468,6 +3683,11 @@ GET {{host}}/pt-br/3.14/library/tkinter.tix.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/tkinter.tix.html
 HTTP 301
@@ -2479,6 +3699,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/tkinter.tix.html
 HTTP 301
 [Asserts]
@@ -2489,6 +3714,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/tkinter.tix.html
 HTTP 301
 [Asserts]
@@ -2498,6 +3728,11 @@ GET {{host}}/zh-cn/3.14/library/tkinter.tix.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/tkinter.tix.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/tkinter.tix.html
 HTTP 301
@@ -2511,6 +3746,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/uu.html -> ''
+GET {{host}}/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/uu.html
 HTTP 301
 [Asserts]
@@ -2520,6 +3760,11 @@ GET {{host}}/3.14/library/uu.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/uu.html
 HTTP 301
@@ -2531,6 +3776,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/uu.html
 HTTP 301
 [Asserts]
@@ -2540,6 +3790,11 @@ GET {{host}}/fr/3.14/library/uu.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/uu.html
 HTTP 301
@@ -2551,6 +3806,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/uu.html
 HTTP 301
 [Asserts]
@@ -2560,6 +3820,11 @@ GET {{host}}/it/3.14/library/uu.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/uu.html
 HTTP 301
@@ -2571,6 +3836,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/uu.html
 HTTP 301
 [Asserts]
@@ -2580,6 +3850,11 @@ GET {{host}}/ko/3.14/library/uu.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/uu.html
 HTTP 301
@@ -2591,6 +3866,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/uu.html
 HTTP 301
 [Asserts]
@@ -2600,6 +3880,11 @@ GET {{host}}/pt-br/3.14/library/uu.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/uu.html
 HTTP 301
@@ -2611,6 +3896,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/uu.html
 HTTP 301
 [Asserts]
@@ -2621,6 +3911,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/uu.html
 HTTP 301
 [Asserts]
@@ -2630,6 +3925,11 @@ GET {{host}}/zh-cn/3.14/library/uu.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/uu.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/uu.html
 HTTP 301
@@ -2643,6 +3943,11 @@ header "Location" == "https://localhost/zh-tw/3.14/"
 
 
 ## Test: Redirect library/xdrlib.html -> ''
+GET {{host}}/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/3/"
+
 GET {{host}}/3.13/library/xdrlib.html
 HTTP 301
 [Asserts]
@@ -2652,6 +3957,11 @@ GET {{host}}/3.14/library/xdrlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/3.14/"
+
+GET {{host}}/es/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/es/3/"
 
 GET {{host}}/es/3.13/library/xdrlib.html
 HTTP 301
@@ -2663,6 +3973,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/es/3.14/"
 
+GET {{host}}/fr/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/fr/3/"
+
 GET {{host}}/fr/3.13/library/xdrlib.html
 HTTP 301
 [Asserts]
@@ -2672,6 +3987,11 @@ GET {{host}}/fr/3.14/library/xdrlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/fr/3.14/"
+
+GET {{host}}/id/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/id/3/"
 
 GET {{host}}/id/3.13/library/xdrlib.html
 HTTP 301
@@ -2683,6 +4003,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/id/3.14/"
 
+GET {{host}}/it/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/it/3/"
+
 GET {{host}}/it/3.13/library/xdrlib.html
 HTTP 301
 [Asserts]
@@ -2692,6 +4017,11 @@ GET {{host}}/it/3.14/library/xdrlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/it/3.14/"
+
+GET {{host}}/ja/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ja/3/"
 
 GET {{host}}/ja/3.13/library/xdrlib.html
 HTTP 301
@@ -2703,6 +4033,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ja/3.14/"
 
+GET {{host}}/ko/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/ko/3/"
+
 GET {{host}}/ko/3.13/library/xdrlib.html
 HTTP 301
 [Asserts]
@@ -2712,6 +4047,11 @@ GET {{host}}/ko/3.14/library/xdrlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/ko/3.14/"
+
+GET {{host}}/pl/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pl/3/"
 
 GET {{host}}/pl/3.13/library/xdrlib.html
 HTTP 301
@@ -2723,6 +4063,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pl/3.14/"
 
+GET {{host}}/pt-br/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/pt-br/3/"
+
 GET {{host}}/pt-br/3.13/library/xdrlib.html
 HTTP 301
 [Asserts]
@@ -2732,6 +4077,11 @@ GET {{host}}/pt-br/3.14/library/xdrlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/pt-br/3.14/"
+
+GET {{host}}/tr/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/tr/3/"
 
 GET {{host}}/tr/3.13/library/xdrlib.html
 HTTP 301
@@ -2743,6 +4093,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/tr/3.14/"
 
+GET {{host}}/uk/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/uk/3/"
+
 GET {{host}}/uk/3.13/library/xdrlib.html
 HTTP 301
 [Asserts]
@@ -2753,6 +4108,11 @@ HTTP 301
 [Asserts]
 header "Location" == "https://localhost/uk/3.14/"
 
+GET {{host}}/zh-cn/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-cn/3/"
+
 GET {{host}}/zh-cn/3.13/library/xdrlib.html
 HTTP 301
 [Asserts]
@@ -2762,6 +4122,11 @@ GET {{host}}/zh-cn/3.14/library/xdrlib.html
 HTTP 301
 [Asserts]
 header "Location" == "https://localhost/zh-cn/3.14/"
+
+GET {{host}}/zh-tw/3/library/xdrlib.html
+HTTP 301
+[Asserts]
+header "Location" == "https://localhost/zh-tw/3/"
 
 GET {{host}}/zh-tw/3.13/library/xdrlib.html
 HTTP 301


### PR DESCRIPTION
Followup to #496, `/3/` is now Python 3.13.

Tests have been added.

A