### PR TITLE
Update bugs.sls - change roundup tracker to WARNING log level

### DIFF
--- a/pillar/base/bugs.sls
+++ b/pillar/base/bugs.sls
@@ -139,7 +139,7 @@ bugs:
       rdbms__isolation_level: "read committed"
       logging__config: ""
       logging__filename: ""
-      logging__level: "ERROR"
+      logging__level: "WARNING"
       mail__domain: ""
       mail__host: "localhost"
       mail__username: ""


### PR DESCRIPTION
Change logging level to warning due to 'Internal Server Error'

EE manual changed logging to level INFO. Restarting to make INFO live cleared the issue. ERROR was the original logging level, but left us with no info for debugging. Try WARNING log level to see if that gives more info if this happens again. INFO is too verbose.

The irc report:
```
    2024-11-20 09:55:03 rouilj: ee, we are getting an 'Internal Server
    Error' on the roundup issue tracker when trying to update
    issues. /var/log/nginx/error.log,
    /var/log/nginx/roundup-roundup.error.log are empty and
    /var/log/roundup/tracker_roundup.log hasn't been updated since oct
    27th. This was working on 2024-11-14 at 9:48 ET. Ideas on where else I
    should look or any changes done since then?
```

<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- 

