### PR TITLE
update logrotate config for cdn-logs

### DIFF
--- a/salt/cdn-logs/config/fastly.logrotate.conf
+++ b/salt/cdn-logs/config/fastly.logrotate.conf
@@ -7,6 +7,6 @@
     delaycompress
     sharedscripts
     postrotate
-        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+        /usr/lib/rsyslog/rsyslog-rotate
     endscript
 }


### PR DESCRIPTION
finally figured out why our log rotate on cdn-logs was all goofy and we were always seeing logs appended to `.1` instead of the expected file :)