### PR TITLE
fix: ensure apt keyring dir exists

### DIFF
--- a/salt/base/salt.sls
+++ b/salt/base/salt.sls
@@ -51,6 +51,7 @@ salt-repo-key:
     - source: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
     - mode: '0644'
     - skip_verify: True
+    - makedirs: True
 
 salt-repo:
   pkgrepo.managed:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- ensure that the apt keyrings directory exists before placing file