### PR TITLE
always set x-client-ip from frontend

### DIFF
--- a/salt/haproxy/config/haproxy.cfg.jinja
+++ b/salt/haproxy/config/haproxy.cfg.jinja
@@ -140,10 +140,10 @@ frontend main
     # Deny requests that are not served from this host
     http-request deny if !our_domains !letsencrypt-well-known-acl
 
+    http-request set-header X-Client-IP %[src]
     # Tell the backend servers whether this request is being served via TLS or
     # not. This should pretty much *always* be yes since we unconditionally
     # redirect to HTTPS in HAProxy.
-    http-request set-header X-Client-IP %[src] if !is_tls
     http-request set-header X-Forwarded-Proto https if is_tls
     http-request set-header X-Forwarded-Proto http  if !is_tls
 


### PR DESCRIPTION
This condition was in place to support the proxy nonsense we had going that was removed in https://github.com/python/psf-salt/pull/543, we can go ahead and always set this now that our frontend is handling tls