### PR TITLE
Add moin access to `adam.sls`

### DIFF
--- a/pillar/base/users/adam.sls
+++ b/pillar/base/users/adam.sls
@@ -7,6 +7,11 @@ users:
         - docs
         - docsbuild
         sudo: true
+      moin:
+        allowed: true
+        groups:
+          - moin
+        sudo: true
     fullname: Adam Turner
     ssh_keys:
     - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEIGz53UVWECxd1h48KLeMtCIVohay+OA639kMNntQCw


### PR DESCRIPTION
Following up on the proposed wiki work from the most recent documentation meeting, we're exploring a `git` replica of the wiki content. Better to do this via the data dump than taxing the already-overloaded web server.