### PR TITLE
Revert "feat: add rate limit to wiki services"

### DIFF
--- a/pillar/base/haproxy.sls
+++ b/pillar/base/haproxy.sls
@@ -84,7 +84,6 @@ haproxy:
         - wiki.jython.org
       verify_host: moin.psf.io
       check: "HEAD /moin/HelpContents HTTP/1.1\\r\\nHost:\\ wiki.python.org"
-      rate_limit: {{ config.get('rate_limit', 50) }}
 
     svn:
       domains:


### PR DESCRIPTION
Reverts python/psf-salt#553

This caused salt to start failing on lbs, which let their certs expire:

```
ee@lb-1:~$ sudo salt-call state.highstate
local:
    Data failed to compile:
----------
    Pillar failed to render with the following messages:
----------
    Rendering SLS 'haproxy' failed. Please see master log for details.
```