### PR TITLE
feat: add rate limit to wiki services

### DIFF
--- a/pillar/base/haproxy.sls
+++ b/pillar/base/haproxy.sls
@@ -83,6 +83,7 @@ haproxy:
         - wiki.python.org
         - wiki.jython.org
       verify_host: moin.psf.io
+      rate_limit: 50
       check: "HEAD /moin/HelpContents HTTP/1.1\\r\\nHost:\\ wiki.python.org"
 
     svn:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- i tested it this time 🥲
```
## with new, working config
 correct state
    loadbalancer:      Started: 17:22:45.765876
    loadbalancer:     Duration: 3.187 ms
    loadbalancer:      Changes:
    loadbalancer: 
    loadbalancer: Summary for local
    loadbalancer: --------------
    loadbalancer: Succeeded: 181 (changed=1)
    loadbalancer: Failed:      0
    loadbalancer: --------------
    loadbalancer: Total states run:     181
    loadbalancer: Total run time:     7.156 s

## With old, broken config:
psf-salt [📝🤷✓] via  pyenv via ⍱ v2.4.3 took 2m27s 
➜ vu loadbalancer
Bringing machine 'loadbalancer' up with 'docker' provider...
==> loadbalancer: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> loadbalancer: flag to force provisioning. Provisioners marked to run always will still run.
==> loadbalancer: Running provisioner: shell...
    loadbalancer: Running: inline script
    loadbalancer: local:
    loadbalancer:     Data failed to compile:
    loadbalancer: ----------
    loadbalancer:     Pillar failed to render with the following messages:
    loadbalancer: ----------
    loadbalancer:     Rendering SLS 'haproxy' failed. Please see master log for details.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```