### PR TITLE
Use the correct spelling of the ``--languages`` flag

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -128,7 +128,7 @@ docsbuild-only-html-en:
         /srv/docsbuild/venv/bin/python
         /srv/docsbuild/scripts/build_docs.py
         --select-output=only-html-en
-        --language=en
+        --languages=en
     - user: docsbuild
     - minute: 16,46
     - require:


### PR DESCRIPTION
docsbuild-scripts expects the languages flag to be ``--languages``, not ``--language``. We want to remove the singular variant, so this updates the usage to allow removal upstream.

A