### PR TITLE
Docsbuild config

### DIFF
--- a/salt/docs/config/docsbuild-scripts
+++ b/salt/docs/config/docsbuild-scripts
@@ -1,0 +1,5 @@
+[env]
+SENTRY_DSN = "{{ sentry_dsn }}"
+FASTLY_SERVICE_ID = "{{ fastly_service_id }}"
+FASTLY_TOKEN = "{{ fastly_token }}"
+PYTHON_DOCS_ENABLE_ANALYTICS = "1"

--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -67,29 +67,17 @@ virtualenv-dependencies:
     - onchanges:
       - git: docsbuild-scripts
 
-docsbuild-analytics:
-  cron.env_present:
+/etc/xdg/docsbuild-scripts:
+  file.managed:
+    - source: salt://docs/config/docsbuild-scripts
+    - template: jinja
+    - context:
+        sentry_dsn: {{ pillar.get('docs', {}).get('sentry', {}).get('dsn', '') }}
+        fastly_service_id: {{ pillar.get('docs', {}).get('fastly', {}).get('service_id', '') }}
+        fastly_token: {{ pillar.get('docs', {}).get('fastly', {}).get('token', '') }}
     - user: docsbuild
-    - name: PYTHON_DOCS_ENABLE_ANALYTICS
-    - value: 1
-
-docsbuild-sentry:
-  cron.env_present:
-    - user: docsbuild
-    - name: SENTRY_DSN
-    - value: {{ pillar.get('docs', {}).get('sentry', {}).get('dsn', '') }}
-
-docsbuild-fastly-service-id:
-  cron.env_present:
-    - user: docsbuild
-    - name: FASTLY_SERVICE_ID
-    - value: {{ pillar.get('docs', {}).get('fastly', {}).get('service_id', '') }}
-
-docsbuild-fastly-token:
-  cron.env_present:
-    - user: docsbuild
-    - name: FASTLY_TOKEN
-    - value: {{ pillar.get('docs', {}).get('fastly', {}).get('token', '') }}
+    - group: docsbuild
+    - mode: "0440"
 
 docsbuild-no-html:
   cron.present:


### PR DESCRIPTION
## Description

Make environment variables specific to docs.python.org available as a configuration file to ensure they're used no matter how the script is invoked.

Note: This limits access to the file to user/group `docsbuild`

Ref: https://github.com/python/docsbuild-scripts/pull/269
Ref: https://github.com/python/docsbuild-scripts/pull/266