### PR TITLE
chore: add cron to restart apache2 daily

### DIFF
--- a/salt/moin/init.sls
+++ b/salt/moin/init.sls
@@ -287,3 +287,14 @@ apache2:
     - user: root
     - group: root
     - mode: "0644"
+
+restart-apache2:
+  cron.present:
+    - name: /usr/bin/systemctl restart apache2
+    - user: root
+    - minute: '0'
+    - hour: '4'
+    - daymonth: '*'
+    - month: '*'
+    - dayweek: '*'
+    - comment: 'Daily Apache2 restart for Moin wiki'


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- apache2 reloads multiple times per day and MAL thinks that this 'may cause `mod_wsgi` to leak memory due to the way finalization works in Python'. this is will be used to see if it helps because after manually restarting the service the stats on the host response times, etc. look better.