### PR TITLE
run planet from dockerized containers, unblock dist upgrade

### DIFF
--- a/pillar/base/planet.sls
+++ b/pillar/base/planet.sls
@@ -3,5 +3,13 @@ planet:
     - planetpython.org
     - www.planetpython.org
   sites:
-    planetpython.org:
+    planetpython:
+      cache: /srv/cache/
+      output: /srv/planetpython.org/
+      image: ghcr.io/python/planetpython:latest
+      config: config.ini
+    planetpython-3:
+      cache: /srv/cache3/
+      output: /srv/planetpython.org/3/
+      image: ghcr.io/python/planetpython-3:latest
       config: config.ini

--- a/salt/planet/config/run-planet.sh.jinja
+++ b/salt/planet/config/run-planet.sh.jinja
@@ -1,5 +1,10 @@
 cd /srv/planet/
 git pull
-{% for site in salt["pillar.get"]("planet", {}).get("sites").values() %}
-$(which python2.7) /srv/planet/code/planet.py /srv/planet/config/{{ site["config"] }}
+{% for site, site_config in salt["pillar.get"]("planet", {}).get("sites").items() %}
+docker run --rm -it \
+  -v {{ site_config["cache"] }}:/srv/cache/ \
+  -v {{ site_config["output"] }}:/srv/planetpython.org/ \
+  -v /srv/planet/config/{{ site_config["config"] }}:/planet/config/config.ini \
+  {{ site_config["image"] }} \
+  python /planet/code/planet.py /planet/config/config.ini
 {% endfor %}

--- a/salt/planet/init.sls
+++ b/salt/planet/init.sls
@@ -4,10 +4,20 @@ include:
 git:
   pkg.installed
 
+docker.io:
+  pkg.installed
+docker:
+  service.running:
+    - enable: True
+
 planet-user:
   user.present:
     - name: planet
     - createhome: False
+    - groups:
+      - docker
+    - require:
+      - pkg: docker.io
 
 /etc/nginx/sites.d/planet.conf:
   file.managed:
@@ -40,7 +50,7 @@ planet-user:
 
 https://github.com/python/planet:
   git.latest:
-    - branch: py2
+    - branch: main
     - target: /srv/planet/
     - user: planet
     - require:

--- a/salt/planet/init.sls
+++ b/salt/planet/init.sls
@@ -58,12 +58,6 @@ https://github.com/python/planet:
       - pkg: git
       - file: /srv/planet/
 
-/srv/cache/:
-  file.directory:
-    - user: planet
-    - group: planet
-    - mode: "0770"
-
 /srv/run-planet.sh:
   file.managed:
     - source: salt://planet/config/run-planet.sh.jinja
@@ -77,18 +71,23 @@ https://github.com/python/planet:
     - minute: 37
     - hour: 1,4,7,10,13,16,19,21
 
-{% for site in salt["pillar.get"]("planet", {}).get("sites", []) %}
-/srv/{{ site }}/:
+{% for site, site_config in salt["pillar.get"]("planet", {}).get("sites", {}).items() %}
+{{ site_config["cache"] }}:
   file.directory:
     - user: planet
     - group: planet
     - mode: "0755"
-/srv/{{ site }}/static:
+{{ site_config["output"] }}:
+  file.directory:
+    - user: planet
+    - group: planet
+    - mode: "0755"
+{{ site_config["output"] }}/static:
   file.symlink:
     - target: /srv/planet/static
     - user: planet
     - group: planet
     - mode: "0644"
     - require:
-      - file: /srv/{{ site }}/
+      - file: {{ site_config["output"] }}
 {% endfor %}


### PR DESCRIPTION
By building and publishing containers for the Python 2 and Python 3 variants, we can just run the actual jobs in Docker.

Py2 image: https://github.com/python/planet/pull/596
Py3 image: https://github.com/python/planet/commit/4cd16ca96927e34a2954b662e4dc0162d8b1d49b