### PR TITLE
buildbot: Use IPv4 address rather than 'localhost'

### DIFF
--- a/salt/buildbot/config/nginx.conf.jinja
+++ b/salt/buildbot/config/nginx.conf.jinja
@@ -33,7 +33,7 @@ server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
-      proxy_pass http://localhost:9010;
+      proxy_pass http://127.0.0.1:9010;
   }
 
   location /robots.txt {


### PR DESCRIPTION
Buildbot does not listen on the IPv6 interface.

<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- 

