### PR TITLE
fix: make sure we source sentry secrets in prod

### DIFF
--- a/pillar/prod/top.sls
+++ b/pillar/prod/top.sls
@@ -11,6 +11,7 @@ base:
     - postgres.clusters
     - secrets.monitoring.datadog
     - swapfile
+    - secrets.sentry
 
   'backup-server':
     - match: nodegroup


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- New deploy doesn't actually work because we don't source it in the pillar data i think