### PR TITLE
fix: update to apt-archive for pg11 on ubuntu focal

### DIFF
--- a/salt/postgresql/base/init.sls
+++ b/salt/postgresql/base/init.sls
@@ -12,6 +12,20 @@ postgresql-repo:
     - require:
       - file: postgresql-key
     - file: /etc/apt/sources.list.d/postgresql.list
+{% elif grains["oscodename"] == "focal" %}
+postgresql-key:
+  file.managed:
+    - name: /etc/apt/keyrings/postgresql.asc
+    - mode: "0644"
+    - source: salt://postgresql/base/APT-GPG-KEY-POSTGRESQL
+
+postgresql-repo:
+  pkgrepo.managed:
+    - name: "deb [signed-by=/etc/apt/keyrings/postgresql.asc arch={{ grains["osarch"] }}] https://apt-archive.postgresql.org/pub/repos/apt {{ grains['oscodename'] }}-pgdg main"
+    - aptkey: False
+    - require:
+      - file: postgresql-key
+    - file: /etc/apt/sources.list.d/postgresql.list
 {% else %}
 postgresql-repo:
   pkgrepo.managed:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- focal is EOL, so pgsql people moved focal repos into `apt-archive` (https://apt-archive.postgresql.org/pub/repos/apt/dists/index.html)

```
  salt-master: Summary for local
    salt-master: --------------
    salt-master: Succeeded: 220 (changed=51)
    salt-master: Failed:      0
    salt-master: Warnings:    2
    salt-master: --------------
    salt-master: Total states run:     220
    salt-master: Total run time:    58.223 s
```

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- 

