### PR TITLE
Reduce frequency of non-HTML documentation builds

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -81,7 +81,7 @@ virtualenv-dependencies:
 
 docsbuild-no-html:
   cron.present:
-    # run every other day at 07:06
+    # run thrice per month at 07:06
     - identifier: docsbuild-no-html
     - name: >
         /srv/docsbuild/venv/bin/python
@@ -90,7 +90,7 @@ docsbuild-no-html:
     - user: docsbuild
     - minute: 7
     - hour: 6
-    - daymonth: '*/2'
+    - daymonth: '*/9'
     - require:
       - cmd: virtualenv-dependencies
 


### PR DESCRIPTION
We currently build ~every 48 hours. This changes the non-HTML (PDF, EPUB, TexInfo, Text) documentation builds to be every nine days, or roughly thrice per month.

A