### PR TITLE
fix: only apply consul on consul

### DIFF
--- a/salt/consul/init.sls
+++ b/salt/consul/init.sls
@@ -117,6 +117,7 @@ consul:
 {% endif %}
 
 
+{% if pillar["dc"] in pillar["consul"]["dcs"] %}
 {% for service in pillar["consul"].get("external", []) %}
 consul-external-{{ service.service }}:
   consul.external_service:
@@ -129,3 +130,4 @@ consul-external-{{ service.service }}:
       - pkg: python-requests
       - service: consul
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- backup*.sfo1.psf.io - in San Francisco (sfo1)
- pythontest*.nyc3.psf.io - in New York (nyc3)

But Consul is only configured for nyc1 datacenter

I think #599 introduced an issue by requiring consul but some places I think don't use it? (outside of nyc1)