### PR TITLE
Increase frequency of English HTML documentation builds

### DIFF
--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -110,7 +110,7 @@ docsbuild-only-html:
 
 docsbuild-only-html-en:
   cron.present:
-    # run twice hourly at HH:16 and HH:46
+    # run every five minutes, starting at HH:01
     - identifier: docsbuild-only-html-en
     - name: >
         /srv/docsbuild/venv/bin/python
@@ -118,7 +118,7 @@ docsbuild-only-html-en:
         --select-output=only-html-en
         --languages=en
     - user: docsbuild
-    - minute: 16,46
+    - minute: '1-59/5'
     - require:
       - cmd: virtualenv-dependencies
 


### PR DESCRIPTION
This increases the frequency of checking for new updates to rebuild for the English HTML-only documentation builds to once every five minutes (offset by one minute).

When there is nothing to do (no changes), the build job exits in less than 3 seconds. When there is work to do (a new documentation change in CPython), a full rebuild takes around three minutes.

Increasing the frequency of rebuilds for HTML-only English should therefore not put significant extra load on the server, whilst also pushing out updates faster after a change is made.

A