### PR TITLE
Update auto-highstate.sls

### DIFF
--- a/salt/base/auto-highstate.sls
+++ b/salt/base/auto-highstate.sls
@@ -16,7 +16,7 @@ curl:
 15m-interval-highstate:
   cron.present:
     - identifier: 15m-interval-highstate
-    - name: "{% if sentry_enabled %}/usr/local/bin/sentry-checkin.sh {% endif %}timeout 5m salt-call state.highstate >> /var/log/salt/cron-highstate.log 2>&1"
+    - name: "{% if sentry_enabled %}/usr/local/bin/sentry-checkin.sh {% endif %}timeout 30m salt-call state.highstate >> /var/log/salt/cron-highstate.log 2>&1"
     - minute: '*/15'
     {% if sentry_enabled %}
     - require:


### PR DESCRIPTION
allow salt high state commands to run up to 30 minutes instead of 5m.

this timeout is what has caused so many of our high state cross to be marked as failure when things like apt mirrors get slow.

its _fine_ for this high state to run as long as needed since salt handles its own locking.