### PR TITLE
fix: perform more complete restart

### DIFF
--- a/salt/moin/init.sls
+++ b/salt/moin/init.sls
@@ -290,7 +290,7 @@ apache2:
 
 restart-apache2:
   cron.present:
-    - name: /usr/bin/systemctl restart apache2
+    - name: /usr/bin/systemctl stop apache2; sleep 5; /usr/bin/systemctl start apache2
     - user: root
     - minute: '0'
     - hour: '4'


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- When we do `systemctl restart apache2` it sometimes leaves forked processes around and doesn't really clean up properly, maybe because it happens too fast with the restart command.