### PR TITLE
prevent 3007 from installing ever

### DIFF
--- a/salt/base/salt.sls
+++ b/salt/base/salt.sls
@@ -41,6 +41,10 @@ salt-pin-config:
         Package: salt-*
         Pin: version 3006.*
         Pin-Priority: 1001
+
+        Package: salt-*
+        Pin: version 3007.*
+        Pin-Priority: -10
     - user: root
     - group: root
     - mode: "0644"


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

I feel like the pinning is "working" because `apt install salt-minion` properly set the version down back to 3006.*

I propose adding a negative pin prio for 3007.* (on top of our existing pin priorty) for now to make sure it just fails if it tries
```
Package: salt-*
Pin: version 3007.*
Pin-Priority: -1
```

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- Closes #618

