### PR TITLE
buildbot: Use IPv4 rather than 'localhost' in nginx config

### DIFF
--- a/salt/buildbot/config/nginx.conf.jinja
+++ b/salt/buildbot/config/nginx.conf.jinja
@@ -48,6 +48,6 @@ server {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
-      proxy_pass http://localhost:9010/ws;
+      proxy_pass http://127.0.0.1:9010/ws;
   }
 }


### PR DESCRIPTION
The buildbot service only listens on IPv4, so use that address explicitly
to avoid polluting the nginx error log.
