### PR TITLE
Add codespeed timeout config

### DIFF
--- a/salt/codespeed/config/codespeed.service.jinja
+++ b/salt/codespeed/config/codespeed.service.jinja
@@ -6,7 +6,7 @@ After=network.target
 Environment=LC_ALL=en_US.UTF-8
 Environment=LANG=en_US.UTF-8
 WorkingDirectory=/srv/codespeed/{{ instance }}/src
-ExecStart=/srv/codespeed/{{ instance }}/env/bin/gunicorn {{ wsgi_app }} -w 4 --bind unix:///var/run/codespeed/{{ instance }}.sock
+ExecStart=/srv/codespeed/{{ instance }}/env/bin/gunicorn {{ wsgi_app }} -w 4 --timeout 300 --bind unix:///var/run/codespeed/{{ instance }}.sock
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStop = /bin/kill -s TERM $MAINPID
 Restart=on-failure

--- a/salt/codespeed/config/nginx.conf.jinja
+++ b/salt/codespeed/config/nginx.conf.jinja
@@ -33,6 +33,10 @@ server {
       proxy_set_header Host $http_host;
       proxy_redirect off;
 
+      # Result uploads insert thousands of rows and run well past the 60s default
+      proxy_read_timeout 300s;
+      proxy_send_timeout 300s;
+
       if (!-f $request_filename) {
           proxy_pass http://codespeed-{{ instance }};
           break;


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Add timeouts for nginx and gunicorn as some uploaders are experiencing 502s and logs indicate timeouts right at 31 seconds
