### PR TITLE
Add nginx redirect for German translation

### DIFF
--- a/salt/docs/config/nginx.docs-redirects.conf
+++ b/salt/docs/config/nginx.docs-redirects.conf
@@ -8,7 +8,7 @@ location = / {
 }
 
 # Python 3 docs are the default at the root of each translation.
-location ~ ^/(bn-in|el|es|fr|id|it|ja|ko|pl|pt-br|ro|ru|sv|tr|uk|zh-cn|zh-tw)/$ {
+location ~ ^/(bn-in|de|el|es|fr|id|it|ja|ko|pl|pt-br|ro|ru|sv|tr|uk|zh-cn|zh-tw)/$ {
     return 302 $scheme://$host/$1/3/;
 }
 
@@ -192,7 +192,7 @@ location ~ ^/((2|3)(\.[0-9]+)?|dev)/ {
     error_page 404 /$1/404.html;
     add_header Surrogate-Key en/$1 always;
 }
-location ~ ^/(bn-in|el|es|fr|id|it|ja|ko|pl|pt-br|ro|ru|tr|sv|uk|zh-cn|zh-tw)/((2|3)(\.[0-9]+)?|dev)/ {
+location ~ ^/(bn-in|de|el|es|fr|id|it|ja|ko|pl|pt-br|ro|ru|tr|sv|uk|zh-cn|zh-tw)/((2|3)(\.[0-9]+)?|dev)/ {
     error_page 404 /$1/$2/404.html;
     add_header Surrogate-Key $1/$2 always;
 }


### PR DESCRIPTION
Adds the `de` language code to the docs redirect rules, following the addition of German to the language switcher.
